### PR TITLE
feat: firebase storage setup

### DIFF
--- a/apps/github-receiver/src/app.ts
+++ b/apps/github-receiver/src/app.ts
@@ -7,11 +7,8 @@ import { HTTP_MESSAGES } from './core/constants/http.constants';
 import { StorageService } from './core/storage';
 
 export const App = async (req: Request, res: Response): Promise<void> => {
-  const rawGithubEvent = req.headers['x-github-event'];
-  const githubEvent = Array.isArray(rawGithubEvent)
-    ? rawGithubEvent[0]
-    : rawGithubEvent;
   const eventId = req.headers['x-github-delivery'] as string;
+  const githubEvent = req.headers['x-github-event'] as string;
   // const signature = req.headers['x-hub-signature-256'] as string;
 
   const payload = req.body;
@@ -26,8 +23,7 @@ export const App = async (req: Request, res: Response): Promise<void> => {
 
     await storageService.storeRawRequest(req, 'github', githubEvent, eventId);
   } catch (error) {
-    console.error('Failed to store raw request:', error);
-    // Decide how to handle the error (e.g., continue processing or return an error response)
+    logger.error('Failed to store raw request:', error);
   }
 
   const eventService = new EventService();

--- a/apps/github-receiver/src/core/storage/index.ts
+++ b/apps/github-receiver/src/core/storage/index.ts
@@ -1,0 +1,1 @@
+export * from './storage.service';

--- a/apps/github-receiver/src/core/storage/storage.service.ts
+++ b/apps/github-receiver/src/core/storage/storage.service.ts
@@ -1,0 +1,32 @@
+import { getStorage, ref, uploadString } from "firebase/storage";
+import { logger } from '@codeheroes/common';
+import { Request } from 'express';
+
+export class StorageService {
+  private storage;
+
+  constructor() {
+    this.storage = getStorage();
+  }
+
+  async storeRawRequest(
+    req: Request,
+    source: string,
+    eventType: string,
+    eventId: string
+  ): Promise<void> {
+    const now = new Date();
+    const timestamp = now.toISOString().replace(/[:.]/g, '-');
+    const filePath = `${source}/${eventType}/${eventId}-${timestamp}.json`;
+
+    const fileRef = ref(this.storage, filePath);
+    try {
+      await uploadString(fileRef, JSON.stringify(req.body), 'raw', {
+        contentType: 'application/json',
+      });
+      logger.info(`Stored raw request at ${filePath}`);
+    } catch (error) {
+      logger.error(`Failed to store raw request at ${filePath}: ${error}`);
+    }
+  }
+}

--- a/apps/github-receiver/src/core/storage/storage.service.ts
+++ b/apps/github-receiver/src/core/storage/storage.service.ts
@@ -1,9 +1,10 @@
-import { getStorage } from 'firebase-admin/storage';
 import { logger } from '@codeheroes/common';
+import { Bucket } from '@google-cloud/storage';
 import { Request } from 'express';
+import { getStorage } from 'firebase-admin/storage';
 
 export class StorageService {
-  private bucket;
+  private bucket: Bucket;
 
   constructor() {
     this.bucket = getStorage().bucket();


### PR DESCRIPTION
This pull request introduces a new `StorageService` to handle the storage of raw GitHub requests and makes several related changes in the `apps/github-receiver` application. The most important changes include the addition of the `StorageService`, modifications to the `App` function to utilize this service, and updates to the handling of unsupported event types.

### Introduction of `StorageService`:

* [`apps/github-receiver/src/core/storage/storage.service.ts`](diffhunk://#diff-b65578952de2aca68081bc936b3db6188840223685ba6d4b4c8ca6221187db73R1-R40): Added a new `StorageService` class to store raw requests in a Google Cloud Storage bucket. The service formats the request data and saves it to a specific file path structure.
* [`apps/github-receiver/src/core/storage/index.ts`](diffhunk://#diff-753772b8b0c87afb1a39d40be0c67eeb2cf6be889015a5636ee104a8c62818b2R1): Exported the `StorageService` from the storage module.

### Modifications to `App` function:

* [`apps/github-receiver/src/app.ts`](diffhunk://#diff-aab800ad215ca50a88ac3e84dfdae485f316f97827759aebf63abf8cf153f07bR7-R35): Imported the `StorageService` and integrated it into the `App` function to store raw GitHub requests before processing them.

### Handling of unsupported event types:

* [`apps/github-receiver/src/app.ts`](diffhunk://#diff-aab800ad215ca50a88ac3e84dfdae485f316f97827759aebf63abf8cf153f07bL33-R55): Improved the readability of the error handling block for unsupported event types by reformatting the condition and response.