### PR TITLE
feat: daily and weekly leaderboard poc

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,6 +5,7 @@ import admin from 'firebase-admin';
 import { CharactersController } from './controllers/characters-controller';
 import { GameController } from './controllers/game-controller';
 import { GamesController } from './controllers/games-controller';
+import { LeaderboardsController } from './controllers/leaderboards-controller';
 import { ScoresController } from './controllers/scores-controller';
 import { UserController } from './controllers/user-controller';
 import { UsersController } from './controllers/users-controller';
@@ -25,5 +26,6 @@ app.use('/characters', CharactersController);
 app.use('/games', GamesController);
 app.use('/game', GameController);
 app.use('/scores', ScoresController);
+app.use('/leaderboards', LeaderboardsController);
 
 export { app as defaultApi };

--- a/apps/api/src/controllers/leaderboards-controller.ts
+++ b/apps/api/src/controllers/leaderboards-controller.ts
@@ -1,0 +1,100 @@
+import { logger } from '@codeheroes/common';
+import { TimeBasedActivityStats, Collections } from '@codeheroes/types';
+import * as express from 'express';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const router = express.Router();
+
+interface TimePeriod {
+  daily: string;
+  weekly: string;
+}
+
+function getISOWeekNumber(date: Date): number {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + 4 - (d.getDay() || 7)); // Set to nearest Thursday
+  const yearStart = new Date(d.getFullYear(), 0, 1);
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
+function getTimePeriodIds(timestamp?: string): TimePeriod {
+  const date = timestamp ? new Date(timestamp) : new Date();
+
+  // Daily ID: YYYY-MM-DD
+  const dailyId = date.toISOString().slice(0, 10);
+
+  // Weekly ID: YYYY-WXX
+  const weekNumber = getISOWeekNumber(date);
+  const weeklyId = `${date.getFullYear()}-W${weekNumber.toString().padStart(2, '0')}`;
+
+  return { daily: dailyId, weekly: weeklyId };
+}
+
+async function getWeeklyXpLeaderboard(weekId?: string) {
+  const db = getFirestore();
+  const recordId = weekId || getTimePeriodIds().weekly;
+
+  // First get all users
+  const usersSnapshot = await db.collection(Collections.Users).get();
+
+  // Then query each user's weekly stats and current stats
+  const userPromises = usersSnapshot.docs.map(async (userDoc) => {
+    const userId = userDoc.id;
+    const userData = userDoc.data();
+    const userDisplayName = userData.displayName || userId;
+
+    // Get weekly stats
+    const weeklyStatDoc = await db
+      .collection(Collections.Users)
+      .doc(userId)
+      .collection('activityStats')
+      .doc('weekly')
+      .collection('records')
+      .doc(recordId)
+      .get();
+
+    // Get current user stats
+    const userStatsDoc = await db
+      .collection(Collections.Users)
+      .doc(userId)
+      .collection(Collections.Stats)
+      .doc('current')
+      .get();
+
+    const weeklyStats = weeklyStatDoc.exists ? (weeklyStatDoc.data() as TimeBasedActivityStats) : null;
+    const userStats = userStatsDoc.exists ? userStatsDoc.data() : null;
+
+    return {
+      userId,
+      displayName: userDisplayName,
+      photoUrl: userData.photoUrl || null,
+      xpGained: weeklyStats?.xpGained || 0,
+      weekId: recordId,
+      // Additional user stats
+      level: userStats?.level || 0,
+      totalXp: userStats?.xp || 0,
+      currentLevelXp: userStats?.currentLevelXp || 0,
+      xpToNextLevel: userStats?.xpToNextLevel || 0,
+    };
+  });
+
+  // Resolve all promises and sort by XP gained this week
+  const results = await Promise.all(userPromises);
+  return results.sort((a, b) => b.xpGained - a.xpGained);
+}
+
+router.get('/week/:weekId?', async (req, res) => {
+  const weekId = req.params.weekId;
+  logger.debug(`GET /leaderboards/week${weekId ? `/${weekId}` : ''}`);
+
+  try {
+    const leaderboard = await getWeeklyXpLeaderboard(weekId);
+    res.json(leaderboard);
+  } catch (error) {
+    logger.error('Error getting weekly leaderboard:', error);
+    res.status(500).json({ error: 'Failed to retrieve weekly leaderboard' });
+  }
+});
+
+export { router as LeaderboardsController };


### PR DESCRIPTION
This pull request introduces a new feature to the API by adding support for leaderboards. The changes include importing and using a new controller for leaderboards and implementing the necessary logic to handle leaderboard data.

### Leaderboard Feature Addition:

* [`apps/api/src/app.ts`](diffhunk://#diff-2c6604b88fe9d8f356771aa58b742b1e86653dbf37577e36532ce2a88aeee665R8): Added `LeaderboardsController` to the list of imports and configured the application to use it for the `/leaderboards` endpoint. [[1]](diffhunk://#diff-2c6604b88fe9d8f356771aa58b742b1e86653dbf37577e36532ce2a88aeee665R8) [[2]](diffhunk://#diff-2c6604b88fe9d8f356771aa58b742b1e86653dbf37577e36532ce2a88aeee665R29)
* [`apps/api/src/controllers/leaderboards-controller.ts`](diffhunk://#diff-5c75b325a415c385d15435a42e696054a064e30ffe6a1a87c23423ba414ab9edR1-R140): Implemented the `LeaderboardsController` with endpoints for daily and weekly leaderboards, including functions to calculate and retrieve leaderboard data from Firestore.