### PR TITLE
introduce userType on user model

### DIFF
--- a/apps/api/src/core/dto/user.dto.ts
+++ b/apps/api/src/core/dto/user.dto.ts
@@ -1,4 +1,5 @@
 import { Expose } from 'class-transformer';
+import { UserType } from '@codeheroes/types';
 
 export class UserDto {
   @Expose()
@@ -18,4 +19,7 @@ export class UserDto {
 
   @Expose()
   lastLogin: string;
+
+  @Expose()
+  userType: UserType;
 }

--- a/apps/auth-service/src/triggers/on-before-user-created.trigger.ts
+++ b/apps/auth-service/src/triggers/on-before-user-created.trigger.ts
@@ -65,6 +65,7 @@ export const onBeforeUserCreated = beforeUserCreated(
         email: user.email,
         displayName: user.displayName ?? user.email,
         photoUrl: user.photoURL,
+        userType: 'user',
       });
 
       // Initialize the user's stats (level 1, 0 XP)

--- a/apps/web/src/app/core/interfaces/user.interface.ts
+++ b/apps/web/src/app/core/interfaces/user.interface.ts
@@ -1,3 +1,5 @@
+import { UserType } from '@codeheroes/types';
+
 export interface IUser {
   active: boolean;
   currentLevelXp: number;
@@ -12,6 +14,7 @@ export interface IUser {
   updatedAt: string;
   xp: number;
   xpToNextLevel: number;
+  userType: UserType;
 }
 
 export interface IUserStats {

--- a/libs/database-seeds/src/lib/data/users.json
+++ b/libs/database-seeds/src/lib/data/users.json
@@ -6,7 +6,8 @@
       "displayName": "User One",
       "photoUrl": "https://example.com/avatar1.jpg",
       "active": true,
-      "lastLogin": "2024-01-01T00:00:00Z"
+      "lastLogin": "2024-01-01T00:00:00Z",
+      "userType": "user"
     },
     {
       "id": "1000002",
@@ -14,7 +15,8 @@
       "displayName": "User Two",
       "photoUrl": "https://example.com/avatar2.jpg",
       "active": false,
-      "lastLogin": "2024-01-01T00:00:00Z"
+      "lastLogin": "2024-01-01T00:00:00Z",
+      "userType": "user"
     }
   ]
 }

--- a/libs/database-seeds/src/lib/seeders/user.seeder.ts
+++ b/libs/database-seeds/src/lib/seeders/user.seeder.ts
@@ -1,5 +1,6 @@
 import { Firestore } from 'firebase-admin/firestore';
 import { Seeder } from '../types/seeder.interface';
+import { UserType } from '@codeheroes/types';
 
 interface User {
   id: string;
@@ -11,6 +12,7 @@ interface User {
   active: boolean;
   createdAt: string; // ISO string
   updatedAt: string; // ISO string
+  userType: UserType;
 }
 
 export class UserSeeder implements Seeder<User> {
@@ -19,8 +21,10 @@ export class UserSeeder implements Seeder<User> {
 
     for (const user of users) {
       const ref = db.collection('users').doc(user.id);
+      // Ensure all users have a userType, default to 'user' if not provided
       batch.set(ref, {
         ...user,
+        userType: user.userType || 'user',
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       });

--- a/libs/server/common/src/user/user.dto.ts
+++ b/libs/server/common/src/user/user.dto.ts
@@ -3,10 +3,12 @@ export interface CreateUserInput {
   email: string | null;
   displayName: string | null;
   photoUrl: string | null;
+  userType?: 'user' | 'bot' | 'system';
 }
 
 export interface UpdateUserInput {
   uid?: string;
   displayName?: string;
   photoUrl?: string;
+  userType?: 'user' | 'bot' | 'system';
 }

--- a/libs/server/common/src/user/user.service.ts
+++ b/libs/server/common/src/user/user.service.ts
@@ -29,6 +29,7 @@ export class UserService extends BaseFirestoreService<User> {
       id: nextId,
       active: true,
       lastLogin: getCurrentTimeAsISO(),
+      userType: input.userType || 'user',
       ...input,
       ...timestamps,
     };

--- a/libs/types/src/lib/user/user.types.ts
+++ b/libs/types/src/lib/user/user.types.ts
@@ -1,5 +1,7 @@
 import { BaseDocument } from '../core/base.types';
 
+export type UserType = 'user' | 'bot' | 'system';
+
 export interface UserDto extends BaseDocument {
   displayName: string;
   email: string;
@@ -7,6 +9,7 @@ export interface UserDto extends BaseDocument {
   active: boolean;
   lastLogin: string; // ISO timestamp
   uid?: string; // Firebase Auth UID
+  userType: UserType;
 }
 
 export interface CreateUserDto {
@@ -14,12 +17,14 @@ export interface CreateUserDto {
   email: string;
   displayName: string;
   photoUrl?: string | null;
+  userType?: UserType; // Default to 'user' if not specified
 }
 
 export interface UpdateUserDto {
   displayName?: string;
   photoUrl?: string;
   active?: boolean;
+  userType?: UserType;
 }
 
 export interface UserProfileDto extends UserDto {


### PR DESCRIPTION
This pull request introduces a new `userType` field across multiple parts of the codebase to better categorize user types. The changes span various files, including DTOs, interfaces, seeders, and service classes.

Key changes include:

### DTO and Interface Updates:
* Added `userType` field to `UserDto` in `apps/api/src/core/dto/user.dto.ts` and `IUser` interface in `apps/web/src/app/core/interfaces/user.interface.ts` to include the user type in user data transfer objects and interfaces. [[1]](diffhunk://#diff-660860d1a900ae0abaa3738673f481f65a68d714f125c8b8f2f3792337744c93R22-R24) [[2]](diffhunk://#diff-cd457eb5f3e622441b4ec54788c22fa5b2c4ccaf62406590a51e1ba1504f16ceR17)

### Seeder and Trigger Updates:
* Updated `user.seeder.ts` to ensure all users have a `userType` field, defaulting to 'user' if not provided.
* Modified `on-before-user-created.trigger.ts` to set the `userType` to 'user' during user creation.

### Type Definition and Service Updates:
* Defined `UserType` in `libs/types/src/lib/user/user.types.ts` to specify possible user types ('user', 'bot', 'system').
* Updated `user.service.ts` to handle the `userType` field when creating a new user.

### Data Seed Updates:
* Added `userType` field to user entries in `users.json` to ensure seed data includes the user type.