### PR TITLE
feat: extend levels to 20

### DIFF
--- a/libs/server/progression-engine/src/lib/config/level-definitions.config.ts
+++ b/libs/server/progression-engine/src/lib/config/level-definitions.config.ts
@@ -96,4 +96,85 @@ export const LEVEL_DEFINITIONS: LevelDefinition[] = [
       badges: ['code_oracle'],
     },
   },
+  {
+    level: 11,
+    xpRequired: 55000, // PoGo L11 Cumulative XP
+    rewards: {
+      title: 'Code Architect', // New plausible title
+      badges: ['code_architect_badge'], // Placeholder badge ID
+    },
+  },
+  {
+    level: 12,
+    xpRequired: 65000, // PoGo L12 Cumulative XP
+    rewards: {
+      title: 'Code Synthesizer',
+      badges: ['code_synthesizer_badge'],
+    },
+  },
+  {
+    level: 13,
+    xpRequired: 75000, // PoGo L13 Cumulative XP
+    rewards: {
+      title: 'Code Virtuoso',
+      badges: ['code_virtuoso_badge'],
+    },
+  },
+  {
+    level: 14,
+    xpRequired: 85000, // PoGo L14 Cumulative XP
+    rewards: {
+      title: 'Code Mentor',
+      badges: ['code_mentor_badge'],
+    },
+  },
+  {
+    level: 15,
+    xpRequired: 100000, // PoGo L15 Cumulative XP
+    rewards: {
+      title: 'Senior Code Hero', // Milestone title
+      badges: ['senior_code_hero_badge', 'level_15_mastery'], // Multiple badges possible
+    },
+  },
+  {
+    level: 16,
+    xpRequired: 120000, // PoGo L16 Cumulative XP
+    rewards: {
+      title: 'Principal Coder',
+      badges: ['principal_coder_badge'],
+    },
+  },
+  {
+    level: 17,
+    xpRequired: 140000, // PoGo L17 Cumulative XP
+    rewards: {
+      title: 'Code Luminary',
+      badges: ['code_luminary_badge'],
+    },
+  },
+  {
+    level: 18,
+    xpRequired: 160000, // PoGo L18 Cumulative XP
+    rewards: {
+      title: 'Distinguished Developer',
+      badges: ['distinguished_developer_badge'],
+    },
+  },
+  {
+    level: 19,
+    xpRequired: 185000, // PoGo L19 Cumulative XP
+    rewards: {
+      title: 'Code Visionary',
+      badges: ['code_visionary_badge'],
+    },
+  },
+  {
+    level: 20,
+    xpRequired: 210000, // PoGo L20 Cumulative XP
+    rewards: {
+      title: 'Grandmaster Coder', // Significant title for L20
+      badges: ['grandmaster_coder_badge', 'level_20_completion'],
+      // unlocks: ['exclusive_avatar_frame'] // Example unlock
+    },
+  },
 ];


### PR DESCRIPTION
This pull request includes significant updates to the level definitions in the `libs/server/progression-engine/src/lib/config/level-definitions.config.ts` file. The changes introduce new levels and corresponding rewards to enhance the progression system.

New level definitions and rewards:

* Added levels 11 to 20 with increasing `xpRequired` values and unique titles and badges for each level.