### PR TITLE
chore: fix outdated references after frontend refactoring

### DIFF
--- a/.claude/commands/dev-setup-start.md
+++ b/.claude/commands/dev-setup-start.md
@@ -1,5 +1,5 @@
 ---
-description: "Start de volledige lokale dev omgeving (emulators, activity-wall, test users)"
+description: "Start de volledige lokale dev omgeving (emulators, app, test users)"
 ---
 
 # Dev Setup Start
@@ -26,10 +26,10 @@ nx serve firebase-app
 
 Start met `run_in_background: true`. Wacht tot "All emulators ready!" verschijnt in de output (controleer met `tail`).
 
-### 3. Start Activity Wall (background)
+### 3. Start App (background)
 
 ```bash
-nx serve activity-wall
+nx serve app
 ```
 
 Start met `run_in_background: true`.

--- a/.firebaserc.template
+++ b/.firebaserc.template
@@ -2,8 +2,8 @@
   "targets": {
     "${FIREBASE_PROJECT_ID}": {
       "hosting": {
-        "web": ["${FIREBASE_PROJECT_ID}"],
-        "activity-wall": ["${FIREBASE_ACTIVITY_WALL_SITE}"]
+        "web-legacy": ["${FIREBASE_PROJECT_ID}"],
+        "app": ["${FIREBASE_ACTIVITY_WALL_SITE}"]
       }
     }
   },

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run setup
 
       - name: Build artifact
-        run: npx nx run web:build
+        run: npx nx run web-legacy:build
 
       - name: Deploy Hosting to Firebase
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,14 @@ CodeHeroes is a gamification platform that tracks developer activity via GitHub 
 codeheroes/
 ├── apps/
 │   ├── firebase-app/     # Firebase orchestrator (emulators, rules)
-│   ├── activity-wall/    # Real-time activity display (Angular)
+│   ├── frontend/
+│   │   ├── app/          # Main PWA app (Angular) - formerly activity-wall
+│   │   └── web-legacy/   # Legacy Angular frontend
 │   ├── api/              # Main REST API (Cloud Function)
 │   ├── auth-service/     # Authentication functions
 │   ├── game-engine/      # Game logic (Eventarc triggered)
 │   ├── github-receiver/  # GitHub webhook handler
-│   ├── github-simulator/ # CLI for simulating GitHub webhooks (testing)
-│   └── web/              # Angular frontend
+│   └── github-simulator/ # CLI for simulating GitHub webhooks (testing)
 ├── libs/
 │   ├── server/common/    # Shared server utilities
 │   └── shared/           # Code shared between server/client
@@ -34,7 +35,7 @@ codeheroes/
 | `npm install` | Install dependencies |
 | `npm run setup` | Generate config files from .env |
 | `nx serve firebase-app` | Start ALL backend emulators |
-| `nx serve web` | Start Angular frontend |
+| `nx serve web-legacy` | Start legacy Angular frontend |
 | `nx serve github-simulator -- push` | Simulate GitHub push event |
 | `nx serve github-simulator -- pr open` | Simulate PR creation |
 | `FIREBASE_PROJECT_ID=your-project-id nx seed database-seeds` | Seed database with test data |
@@ -505,18 +506,18 @@ nx run firebase-app:firebase deploy --only hosting
 
 ---
 
-## Activity Wall App
+## Code Heroes App (Main PWA)
 
-A separate Angular app for displaying real-time activity on TV/public displays.
+The main Angular app for displaying real-time activity on TV/public displays.
 
 | Item | Value |
 |------|-------|
-| Location | `apps/activity-wall/` |
+| Location | `apps/frontend/app/` |
 | Port | 4201 |
-| Start (local) | `nx serve activity-wall` |
-| Start (test) | `nx serve activity-wall --configuration=test` |
-| Deploy (test) | `nx run firebase-app:firebase deploy --only hosting:activity-wall` (uses test project) |
-| Deploy (prod) | `nx run firebase-app:firebase deploy --only hosting:activity-wall` (uses prod project) |
+| Start (local) | `nx serve app` |
+| Start (test) | `nx serve app --configuration=test` |
+| Deploy (test) | `nx run firebase-app:firebase deploy --only hosting:app` (uses test project) |
+| Deploy (prod) | `nx run firebase-app:firebase deploy --only hosting:app` (uses prod project) |
 
 ---
 
@@ -662,7 +663,7 @@ The Firebase Auth Emulator accepts fake Google credentials. The flow:
 ### Step 1: Call Auth Emulator REST API
 
 ```bash
-# Get your API key from apps/activity-wall/src/environments/environment.ts
+# Get your API key from apps/frontend/app/src/environments/environment.ts
 API_KEY="your-firebase-api-key"
 
 # Create URL-encoded id_token payload

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A monorepo project built with [Nx](https://nx.dev) workspace architecture.
 - [firebase-app](apps/firebase-app) - Main Firebase application
 - [game-engine](apps/game-engine) - Game engine Firebase function
 - [github-receiver](apps/github-receiver) - GitHub webhooks receiver Firebase function
-- [web](apps/web) - Web application
+- [app](apps/frontend/app) - Main PWA application (Activity Wall)
+- [web-legacy](apps/frontend/web-legacy) - Legacy web application
 
 ### Libraries
 
@@ -72,9 +73,11 @@ A monorepo project built with [Nx](https://nx.dev) workspace architecture.
      ```
      This will:
    - Generate `.firebaserc` file with your project ID
-   - Create environment files for the web application:
-     - `apps/web/src/environments/environment.local.ts` (development)
-     - `apps/web/src/environments/environment.prod.ts` (production)
+   - Create environment files for the web applications:
+     - `apps/frontend/web-legacy/src/environments/environment.local.ts` (development)
+     - `apps/frontend/web-legacy/src/environments/environment.prod.ts` (production)
+     - `apps/frontend/app/src/environments/environment.local.ts` (development)
+     - `apps/frontend/app/src/environments/environment.prod.ts` (production)
 
 3. Start development environment:
 

--- a/apps/firebase-app/firestore.rules
+++ b/apps/firebase-app/firestore.rules
@@ -17,7 +17,7 @@ service cloud.firestore {
     // ============================================
     match /users/{userId} {
       // Any authenticated user can read basic profile info
-      // (displayName, photoUrl needed for activity-wall)
+      // (displayName, photoUrl needed for app)
       allow read: if isAuthenticated();
 
       // User can only update their own profile (match auth UID to document's uid field)

--- a/apps/frontend/app/README.md
+++ b/apps/frontend/app/README.md
@@ -1,4 +1,4 @@
-# Activity Wall
+# Code Heroes App
 
 Real-time activity feed display for TV/public screens. Shows developer activities (commits, PRs, reviews) as they happen.
 
@@ -8,8 +8,8 @@ Real-time activity feed display for TV/public screens. Shows developer activitie
 
 | Environment       | Command                                       | Description                       |
 | ----------------- | --------------------------------------------- | --------------------------------- |
-| Local (emulators) | `nx serve activity-wall`                      | Uses local Firebase emulators     |
-| Test              | `nx serve activity-wall --configuration=test` | Connects to test Firebase project |
+| Local (emulators) | `nx serve app`                      | Uses local Firebase emulators     |
+| Test              | `nx serve app --configuration=test` | Connects to test Firebase project |
 
 **URLs:**
 
@@ -20,20 +20,20 @@ Real-time activity feed display for TV/public screens. Shows developer activitie
 
 | Environment | Command                                             |
 | ----------- | --------------------------------------------------- |
-| Test        | `nx build activity-wall --configuration=test`       |
-| Production  | `nx build activity-wall --configuration=production` |
+| Test        | `nx build app --configuration=test`       |
+| Production  | `nx build app --configuration=production` |
 
-Output: `dist/apps/activity-wall/browser/`
+Output: `dist/apps/frontend/app/browser/`
 
 ## Deployment
 
-Activity Wall is deployed to Firebase Hosting as a separate site.
+Code Heroes App is deployed to Firebase Hosting as a separate site.
 
 ```bash
-# Deploy activity-wall only
-nx run firebase-app:firebase deploy --only hosting:activity-wall
+# Deploy app only
+nx run firebase-app:firebase deploy --only hosting:app
 
-# Deploy all hosting sites (web + activity-wall)
+# Deploy all hosting sites (web-legacy + app)
 nx run firebase-app:firebase deploy --only hosting
 ```
 

--- a/apps/frontend/app/jest.config.ts
+++ b/apps/frontend/app/jest.config.ts
@@ -1,5 +1,5 @@
 module.exports = {
-  displayName: 'activity-wall',
+  displayName: 'app',
   preset: '../../../jest.preset.js',
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   coverageDirectory: '../../../coverage/apps/frontend/app',

--- a/apps/frontend/app/project.json
+++ b/apps/frontend/app/project.json
@@ -87,7 +87,7 @@
           "buildTarget": "app:build:test"
         },
         "development": {
-          "buildTarget": "activity-wall:build:development"
+          "buildTarget": "app:build:development"
         }
       },
       "defaultConfiguration": "development",

--- a/docs/architecture/activity-stream.md
+++ b/docs/architecture/activity-stream.md
@@ -290,7 +290,7 @@ A stack shows:
 
 ### Real-Time Feed Service
 
-**Location:** `apps/activity-wall/src/app/core/services/activity-feed.service.ts`
+**Location:** `apps/frontend/app/src/app/core/services/activity-feed.service.ts`
 
 ```typescript
 // Real-time subscription
@@ -304,7 +304,7 @@ loadMoreActivities(lastDoc, limit = 50): Promise<LoadMoreResult>
 
 ### Display Mapping
 
-**Location:** `apps/activity-wall/src/app/core/mappings/action-type.mapping.ts`
+**Location:** `apps/frontend/app/src/app/core/mappings/action-type.mapping.ts`
 
 Each activity type has visual configuration:
 
@@ -355,14 +355,14 @@ Creates reward activities:
 - `recordLevelUp(userId, prevLevel, newLevel, xp)` - Level up
 
 ### ActivityFeedService (Frontend)
-**Location:** `apps/activity-wall/src/app/core/services/activity-feed.service.ts`
+**Location:** `apps/frontend/app/src/app/core/services/activity-feed.service.ts`
 
 Queries activities:
 - `getGlobalActivities(limit)` - Real-time subscription
 - `loadMoreActivities(lastDoc, limit)` - Pagination
 
 ### ActivityStackerService (Frontend)
-**Location:** `apps/activity-wall/src/app/core/services/activity-stacker.service.ts`
+**Location:** `apps/frontend/app/src/app/core/services/activity-stacker.service.ts`
 
 Groups related activities:
 - `stackActivities(activities)` - Returns stacks or singles

--- a/docs/architecture/badge-system.md
+++ b/docs/architecture/badge-system.md
@@ -359,7 +359,7 @@ Badges appear in:
 2. **User Profile** - Grid of earned badges
 3. **Debug Panel** - Full activity JSON for development
 
-The `activity-wall` app uses:
+The `app` (main PWA) uses:
 - `ACTIVITY_TYPE_DISPLAY` mapping for badge/level-up styling
 - `getActivityTypeDisplay()` to get display config
 - Type guards (`isBadgeEarnedActivity`, `isLevelUpActivity`) for type-safe rendering

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -73,12 +73,13 @@ codeheroes/
 │   ├── github-simulator/    # CLI for simulating GitHub webhooks
 │   │   └── src/             # Testing tool
 │   │
-│   ├── activity-wall/       # Real-time activity display (Angular)
-│   │   └── src/             # TV/public display app
-│   │
-│   └── web/                 # Angular frontend
-│       └── src/
-│           └── environments/ # Firebase config
+│   └── frontend/
+│       ├── app/             # Main PWA app (Angular) - real-time activity display
+│       │   └── src/         # TV/public display app
+│       │
+│       └── web-legacy/      # Legacy Angular frontend
+│           └── src/
+│               └── environments/ # Firebase config
 │
 ├── libs/                    # Shared libraries
 │   ├── server/
@@ -181,8 +182,8 @@ codeheroes/
 | `npm install` | Install all dependencies |
 | `npm run setup` | Generate config files from .env |
 | `nx serve firebase-app` | Start all emulators + watch mode |
-| `nx serve web` | Start Angular dev server |
-| `nx serve activity-wall` | Start activity wall display |
+| `nx serve web-legacy` | Start legacy Angular dev server |
+| `nx serve app` | Start main PWA app |
 | `nx serve github-simulator -- push` | Simulate GitHub push event |
 | `nx build api` | Build api functions |
 | `nx run firebase-app:killports` | Kill all emulator ports |

--- a/docs/contributing/github-labels.md
+++ b/docs/contributing/github-labels.md
@@ -35,8 +35,8 @@ Labels that identify which part of the codebase an issue relates to.
 
 | Label | Color | Description |
 |-------|-------|-------------|
-| `app: web` | ![#5319e7](https://via.placeholder.com/15/5319e7/5319e7.png) `#5319e7` | Frontend web app (`apps/web`) |
-| `app: activity-wall` | ![#5319e7](https://via.placeholder.com/15/5319e7/5319e7.png) `#5319e7` | Activity wall display (`apps/activity-wall`) |
+| `app: web-legacy` | ![#5319e7](https://via.placeholder.com/15/5319e7/5319e7.png) `#5319e7` | Legacy frontend web app (`apps/frontend/web-legacy`) |
+| `app: app` | ![#5319e7](https://via.placeholder.com/15/5319e7/5319e7.png) `#5319e7` | Main PWA app (`apps/frontend/app`) |
 | `app: api` | ![#1d76db](https://via.placeholder.com/15/1d76db/1d76db.png) `#1d76db` | REST API (`apps/api`) |
 | `app: game-engine` | ![#1d76db](https://via.placeholder.com/15/1d76db/1d76db.png) `#1d76db` | Game logic/XP processing (`apps/game-engine`) |
 | `app: github-receiver` | ![#1d76db](https://via.placeholder.com/15/1d76db/1d76db.png) `#1d76db` | Webhook handler (`apps/github-receiver`) |

--- a/docs/local-development/02-environment-setup.md
+++ b/docs/local-development/02-environment-setup.md
@@ -57,9 +57,11 @@ The script (`scripts/setup-firebase.js`) generates:
 | Generated File | Template | Purpose |
 |----------------|----------|---------|
 | `.firebaserc` | `.firebaserc.template` | Firebase project targeting |
-| `apps/web/src/environments/environment.local.ts` | `environment.ts.template` | Local Angular config |
-| `apps/web/src/environments/environment.prod.ts` | `environment.ts.template` | Production Angular config |
-| `apps/web/public/firebase-messaging-sw.js` | `firebase-messaging-sw.js.template` | Push notification service worker |
+| `apps/frontend/web-legacy/src/environments/environment.local.ts` | `environment.ts.template` | Local Angular config |
+| `apps/frontend/web-legacy/src/environments/environment.prod.ts` | `environment.ts.template` | Production Angular config |
+| `apps/frontend/web-legacy/public/firebase-messaging-sw.js` | `firebase-messaging-sw.js.template` | Push notification service worker |
+| `apps/frontend/app/src/environments/environment.local.ts` | `environment.local.ts.template` | Local App config |
+| `apps/frontend/app/src/environments/environment.prod.ts` | `environment.prod.ts.template` | Production App config |
 
 ## Step 4: Verify Generated Files
 
@@ -69,11 +71,14 @@ Check that all files were generated:
 # Firebase project config
 cat .firebaserc
 
-# Angular environment files
-ls -la apps/web/src/environments/
+# Angular environment files (legacy)
+ls -la apps/frontend/web-legacy/src/environments/
+
+# Angular environment files (app)
+ls -la apps/frontend/app/src/environments/
 
 # Service worker
-ls -la apps/web/public/firebase-messaging-sw.js
+ls -la apps/frontend/web-legacy/public/firebase-messaging-sw.js
 ```
 
 Expected `.firebaserc` content:
@@ -103,8 +108,10 @@ Ensure all required variables are in `.env`:
 
 Ensure these template files exist:
 - `.firebaserc.template`
-- `apps/web/src/environments/environment.ts.template`
-- `apps/web/public/firebase-messaging-sw.js.template`
+- `apps/frontend/web-legacy/src/environments/environment.ts.template`
+- `apps/frontend/web-legacy/public/firebase-messaging-sw.js.template`
+- `apps/frontend/app/src/environments/environment.local.ts.template`
+- `apps/frontend/app/src/environments/environment.prod.ts.template`
 
 ### Setup complete?
 

--- a/docs/local-development/08-deployment.md
+++ b/docs/local-development/08-deployment.md
@@ -211,7 +211,7 @@ nx run firebase-app:firebase functions:list
 
 **CRITICAL NOTE: Firebase Hosting for this project (`codeheroes-app-test`) is currently suspended due to a policy violation.**
 
-Attempts to deploy frontend applications (e.g., `apps/web` and `apps/activity-wall`) to Firebase Hosting will appear to succeed but the deployed sites will return a 404 "Site Not Found" error.
+Attempts to deploy frontend applications (e.g., `apps/frontend/web-legacy` and `apps/frontend/app`) to Firebase Hosting will appear to succeed but the deployed sites will return a 404 "Site Not Found" error.
 
 To resolve this, the project owner must:
 1. Review the project for any content that violates Google Cloud's Terms of Service (e.g., phishing content) and secure the project if compromised.

--- a/docs/plans/badge-system-mvp.md
+++ b/docs/plans/badge-system-mvp.md
@@ -614,7 +614,7 @@ Fix any failing tests.
 
 Add badge display to the Activity Wall.
 
-**File**: `apps/activity-wall/src/app/components/badges/badge-list.component.ts`
+**File**: `apps/frontend/app/src/app/components/badges/badge-list.component.ts`
 
 Create a component that:
 1. Fetches user badges from Firestore
@@ -724,7 +724,7 @@ When ALL success criteria are met and verified:
 
 ### New Files:
 - `libs/server/progression-engine/src/lib/config/badge-catalog.config.ts`
-- `apps/activity-wall/src/app/components/badges/badge-list.component.ts` (or similar)
+- `apps/frontend/app/src/app/components/badges/badge-list.component.ts` (or similar)
 
 ### Modified Files:
 - `libs/types/src/lib/gamification/badges.types.ts`
@@ -741,5 +741,5 @@ When ALL success criteria are met and verified:
 1. **Test after each phase** - Don't wait until the end
 2. **Check emulator logs** - Look for errors in the Firebase emulator output
 3. **Use DevTools MCP** - For browser verification, use `mcp__devtools-mcp__take_screenshot`
-4. **Activity Wall structure** - Explore `apps/activity-wall/src/app` to understand current component structure before adding badge display
+4. **App structure** - Explore `apps/frontend/app/src/app` to understand current component structure before adding badge display
 5. **Firestore rules** - Badge collection should be readable by the user (check existing rules)


### PR DESCRIPTION
## Summary

- Fix all outdated references after moving frontend apps to new locations:
  - `apps/activity-wall` → `apps/frontend/app` (project name: `app`)
  - `apps/web` → `apps/frontend/web-legacy` (project name: `web-legacy`)
- Update 16 files with correct paths, project names, and commands

## Changes

### Critical Fixes (Breaking)
- Fix `buildTarget` in `apps/frontend/app/project.json` (was `activity-wall:build:development`)
- Update `.firebaserc.template` hosting targets (`web` → `web-legacy`, `activity-wall` → `app`)
- Update GitHub workflow to use `nx run web-legacy:build`

### Documentation Updates
- `CLAUDE.md` - Repository structure, commands, Activity Wall section
- `README.md` - App links and environment file paths
- All docs in `docs/architecture/`, `docs/local-development/`, `docs/contributing/`, `docs/plans/`

### Other Updates
- Jest config displayName
- Dev setup command
- Firestore rules comment

## Test plan

- [x] `nx show projects` lists both `app` and `web-legacy`
- [x] App project serve target correctly references `app:build:development`
- [ ] `nx serve app` starts without errors
- [ ] `npm run setup` generates correct config files

🤖 Generated with [Claude Code](https://claude.com/claude-code)