### PR TITLE
chore(app): remove live indicator from page headers

### DIFF
--- a/apps/frontend/app/src/app/pages/activity-wall/activity-wall.component.ts
+++ b/apps/frontend/app/src/app/pages/activity-wall/activity-wall.component.ts
@@ -16,16 +16,8 @@ import { DebugPanelComponent } from '../../components/debug-panel.component';
   template: `
     <!-- Header -->
     <header class="sticky top-0 z-20 bg-black/90 backdrop-blur-sm px-4 py-4 md:px-8 md:py-5">
-      <div class="flex items-center justify-between relative z-10">
+      <div class="relative z-10">
         <h1 class="text-2xl md:text-4xl font-bold italic text-white">Activity Wall</h1>
-        <div
-          class="flex items-center gap-2 px-3 py-1.5 rounded border border-green-500/30 bg-black/50"
-          role="status"
-          aria-label="Real-time updates active"
-        >
-          <span class="w-2.5 h-2.5 rounded-full bg-green-400 live-indicator"></span>
-          <span class="text-sm md:text-base text-green-400 font-mono">LIVE</span>
-        </div>
       </div>
     </header>
 

--- a/apps/frontend/app/src/app/pages/hq/hq.component.ts
+++ b/apps/frontend/app/src/app/pages/hq/hq.component.ts
@@ -19,16 +19,8 @@ import { HighlightsComponent } from './components/highlights.component';
   template: `
     <!-- Header -->
     <header class="sticky top-0 z-20 bg-black/90 backdrop-blur-sm px-4 py-4 md:px-6 lg:px-8 md:py-5">
-      <div class="flex items-center justify-between relative z-10">
+      <div class="relative z-10">
         <h1 class="text-2xl md:text-4xl font-bold italic text-white">HQ</h1>
-        <div
-          class="card-glow-green flex items-center gap-2 px-3 py-1.5 rounded bg-black/50"
-          role="status"
-          aria-label="Real-time updates active"
-        >
-          <span class="w-2.5 h-2.5 rounded-full live-indicator" style="background-color: var(--neon-green)"></span>
-          <span class="text-sm md:text-base font-mono" style="color: var(--neon-green)">LIVE</span>
-        </div>
       </div>
     </header>
 

--- a/apps/frontend/app/src/app/pages/profile/profile.component.ts
+++ b/apps/frontend/app/src/app/pages/profile/profile.component.ts
@@ -30,16 +30,7 @@ import { MyStatsComponent } from './components/my-stats.component';
     <header class="sticky top-0 z-20 bg-black/90 backdrop-blur-sm px-4 py-4 md:px-6 lg:px-8 md:py-5">
       <div class="flex items-center justify-between relative z-10">
         <h1 class="text-2xl md:text-4xl font-bold italic text-white">Profile</h1>
-        <div class="flex items-center gap-3">
-          <div
-            class="card-glow-green flex items-center gap-2 px-3 py-1.5 rounded bg-black/50"
-            role="status"
-            aria-label="Real-time updates active"
-          >
-            <span class="w-2.5 h-2.5 rounded-full live-indicator" style="background-color: var(--neon-green)"></span>
-            <span class="text-sm md:text-base font-mono" style="color: var(--neon-green)">LIVE</span>
-          </div>
-          <button
+        <button
             type="button"
             (click)="logout()"
             aria-label="Sign out"
@@ -54,7 +45,6 @@ import { MyStatsComponent } from './components/my-stats.component';
               />
             </svg>
           </button>
-        </div>
       </div>
     </header>
 

--- a/apps/frontend/app/src/styles.scss
+++ b/apps/frontend/app/src/styles.scss
@@ -146,23 +146,6 @@ body {
   animation: slideInGlow 0.5s ease-out forwards;
 }
 
-/* Live indicator pulse - enhanced for TV visibility */
-@keyframes livePulse {
-  0%,
-  100% {
-    box-shadow: 0 0 0 0 rgba(0, 255, 136, 0.9);
-    filter: brightness(1);
-  }
-  50% {
-    box-shadow: 0 0 0 8px rgba(0, 255, 136, 0);
-    filter: brightness(1.3);
-  }
-}
-
-.live-indicator {
-  animation: livePulse 2s ease-in-out infinite;
-}
-
 /* Scrollbar styling for dark theme */
 ::-webkit-scrollbar {
   width: 6px;


### PR DESCRIPTION
## Summary
- Remove the "LIVE" indicator badge from the HQ, Profile, and Activity Wall page headers
- Remove associated CSS animation for the live pulse effect
- The indicator doesn't add significant value to the user experience

## Test plan
- [x] Verify HQ page renders without the live indicator
- [x] Verify Profile page renders without the live indicator  
- [x] Verify Activity Wall renders without the live indicator
- [x] Check that no console errors appear
