### PR TITLE
fix(integrations): add missing provider field to GitHub issue event mapping

### DIFF
--- a/libs/server/integrations/src/lib/providers/github/github.adapter.ts
+++ b/libs/server/integrations/src/lib/providers/github/github.adapter.ts
@@ -366,6 +366,7 @@ export class GitHubAdapter implements ProviderAdapter {
       type: actionType,
       userId,
       externalId: String(event.issue.id),
+      provider: 'github',
       timestamp: event.issue.updated_at,
       externalUser: {
         id: String(event.sender.id),


### PR DESCRIPTION
## Summary

- The `mapIssueEvent()` method in the GitHub adapter was the only event mapping method missing `provider: 'github'` in its return object
- This caused `issue_open` and `issue_close` GameActions to be stored without a provider, leading to unmatched event records with `undefined` as the provider key (e.g. document ID `undefined_dutchhackers_codeheroes`)
- Cleaned up the corrupt Firestore document in test environment

## Root cause

All other mapping methods (`mapCodePushEvent`, `mapPullRequestEvent`, `mapReviewEvent`, etc.) correctly include `provider: 'github'` — this was simply missed when `mapIssueEvent` was implemented.

## Test plan

- [x] Verify build passes
- [x] Confirm all other mapping methods already include provider field
- [x] Deleted corrupt `unmatchedEvents/undefined_dutchhackers_codeheroes` document from Firestore