### PR TITLE
feat: GitHub App self-service repository management

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -13,6 +13,7 @@ import { LeaderboardsController } from './controllers/leaderboards-controller';
 import { ProjectsController } from './controllers/projects-controller';
 import { ScoresController } from './controllers/scores-controller';
 import { TrendsController } from './controllers/trends-controller';
+import { InstallationsController } from './controllers/installations-controller';
 import { UnmatchedEventsController } from './controllers/unmatched-events-controller';
 import { UserController } from './controllers/user-controller';
 import { UsersController } from './controllers/users-controller';
@@ -83,6 +84,7 @@ app.use('/scores', ScoresController);
 app.use('/leaderboards', LeaderboardsController);
 app.use('/projects', ProjectsController);
 app.use('/trends', TrendsController);
+app.use('/installations', InstallationsController);
 app.use('/unmatched-events', UnmatchedEventsController);
 
 export { app as defaultApi };

--- a/apps/api/src/controllers/installations-controller.ts
+++ b/apps/api/src/controllers/installations-controller.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { DatabaseInstance, logger } from '@codeheroes/common';
 import { InstallationRepository } from '@codeheroes/common';
 import { GitHubAppService } from '@codeheroes/integrations';
+import { BadgeService } from '@codeheroes/progression-engine';
 import { GitHubInstallation, InstallationSummaryDto } from '@codeheroes/types';
 import { validate } from '../middleware/validate.middleware';
 import { adminMiddleware } from '../middleware/admin.middleware';
@@ -65,6 +66,11 @@ router.post('/setup', validate(setupSchema), async (req, res) => {
           String(installationId),
         );
 
+        // Grant "Connected" badge for first repo link
+        new BadgeService().grantBadge(userId, 'connected').catch((err) =>
+          logger.warn('Failed to grant connected badge', { userId, error: err?.message }),
+        );
+
         res.status(201).json(toSummary(installation));
         return;
       } catch (fetchError: any) {
@@ -88,6 +94,11 @@ router.post('/setup', validate(setupSchema), async (req, res) => {
     if (!installation.linkedUserId) {
       await repo.linkToUser(installation.id, userId);
       installation.linkedUserId = userId;
+
+      // Grant "Connected" badge for first repo link
+      new BadgeService().grantBadge(userId, 'connected').catch((err) =>
+        logger.warn('Failed to grant connected badge', { userId, error: err?.message }),
+      );
     }
 
     res.json(toSummary(installation));

--- a/apps/api/src/controllers/installations-controller.ts
+++ b/apps/api/src/controllers/installations-controller.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { DatabaseInstance, logger } from '@codeheroes/common';
 import { InstallationRepository } from '@codeheroes/common';
 import { GitHubAppService } from '@codeheroes/integrations';
-import { InstallationSummaryDto } from '@codeheroes/types';
+import { GitHubInstallation, InstallationSummaryDto } from '@codeheroes/types';
 import { validate } from '../middleware/validate.middleware';
 import { adminMiddleware } from '../middleware/admin.middleware';
 
@@ -47,7 +47,7 @@ router.post('/setup', validate(setupSchema), async (req, res) => {
         installation = await repo.create(
           {
             githubInstallationId: installationId,
-            appId: ghInstallation.id,
+            appId: ghInstallation.app_id,
             accountLogin: ghInstallation.account.login,
             accountId: ghInstallation.account.id,
             accountType: ghInstallation.account.type === 'Organization' ? 'Organization' : 'User',
@@ -123,6 +123,24 @@ router.get('/', async (req, res) => {
 });
 
 /**
+ * GET /installations/admin/all
+ * Admin overview of all installations.
+ */
+router.get('/admin/all', adminMiddleware, async (req, res) => {
+  logger.debug('GET /installations/admin/all');
+
+  try {
+    const repo = new InstallationRepository(DatabaseInstance.getInstance());
+    const installations = await repo.findAll(500);
+
+    res.json(installations.map(toSummary));
+  } catch (error) {
+    logger.error('Error listing all installations:', error);
+    res.status(500).json({ error: 'Failed to list installations' });
+  }
+});
+
+/**
  * GET /installations/:id
  * Get installation detail (owner or admin).
  */
@@ -192,25 +210,7 @@ router.delete('/:id', async (req, res) => {
   }
 });
 
-/**
- * GET /installations/admin/all
- * Admin overview of all installations.
- */
-router.get('/admin/all', adminMiddleware, async (req, res) => {
-  logger.debug('GET /installations/admin/all');
-
-  try {
-    const repo = new InstallationRepository(DatabaseInstance.getInstance());
-    const installations = await repo.findAll(500);
-
-    res.json(installations.map(toSummary));
-  } catch (error) {
-    logger.error('Error listing all installations:', error);
-    res.status(500).json({ error: 'Failed to list installations' });
-  }
-});
-
-function toSummary(installation: any): InstallationSummaryDto {
+function toSummary(installation: GitHubInstallation): InstallationSummaryDto {
   return {
     id: installation.id,
     accountLogin: installation.accountLogin,

--- a/apps/api/src/controllers/installations-controller.ts
+++ b/apps/api/src/controllers/installations-controller.ts
@@ -1,0 +1,223 @@
+import * as express from 'express';
+import { z } from 'zod';
+import { DatabaseInstance, logger } from '@codeheroes/common';
+import { InstallationRepository } from '@codeheroes/common';
+import { GitHubAppService } from '@codeheroes/integrations';
+import { InstallationSummaryDto } from '@codeheroes/types';
+import { validate } from '../middleware/validate.middleware';
+import { adminMiddleware } from '../middleware/admin.middleware';
+
+const router = express.Router();
+
+const setupSchema = z.object({
+  installationId: z.number().int().positive(),
+  setupAction: z.enum(['install', 'update', 'request']),
+});
+
+/**
+ * POST /installations/setup
+ * Called after GitHub redirects back to the PWA with installation_id.
+ * Links the GitHub App installation to the current user.
+ */
+router.post('/setup', validate(setupSchema), async (req, res) => {
+  const { installationId, setupAction } = req.body;
+  const userId = req.user?.customUserId;
+
+  if (!userId) {
+    res.status(401).json({ error: 'User identity not found' });
+    return;
+  }
+
+  logger.debug('POST /installations/setup', { installationId, setupAction, userId });
+
+  try {
+    const repo = new InstallationRepository(DatabaseInstance.getInstance());
+    let installation = await repo.findByGithubInstallationId(installationId);
+
+    // Race condition: webhook may not have arrived yet.
+    // Fetch installation details from GitHub API and create the record.
+    if (!installation) {
+      try {
+        const appService = new GitHubAppService();
+        const [ghInstallation, ghRepos] = await Promise.all([
+          appService.getInstallation(installationId),
+          appService.getInstallationRepositories(installationId),
+        ]);
+
+        installation = await repo.create(
+          {
+            githubInstallationId: installationId,
+            appId: ghInstallation.id,
+            accountLogin: ghInstallation.account.login,
+            accountId: ghInstallation.account.id,
+            accountType: ghInstallation.account.type === 'Organization' ? 'Organization' : 'User',
+            repositories: ghRepos.map((r) => ({
+              id: r.id,
+              name: r.name,
+              fullName: r.full_name,
+              private: r.private,
+            })),
+            permissions: ghInstallation.permissions,
+            events: ghInstallation.events,
+            status: 'active',
+            linkedUserId: userId,
+          },
+          String(installationId),
+        );
+
+        res.status(201).json(toSummary(installation));
+        return;
+      } catch (fetchError) {
+        logger.error('Failed to fetch installation from GitHub', { installationId, error: fetchError });
+        res.status(404).json({ error: 'Installation not found. Please try again in a moment.' });
+        return;
+      }
+    }
+
+    // Already linked to another user
+    if (installation.linkedUserId && installation.linkedUserId !== userId) {
+      res.status(409).json({ error: 'This installation is already linked to another account' });
+      return;
+    }
+
+    // Link to current user
+    if (!installation.linkedUserId) {
+      await repo.linkToUser(installation.id, userId);
+      installation.linkedUserId = userId;
+    }
+
+    res.json(toSummary(installation));
+  } catch (error) {
+    logger.error('Error setting up installation:', error);
+    res.status(500).json({ error: 'Failed to set up installation' });
+  }
+});
+
+/**
+ * GET /installations
+ * List current user's linked installations.
+ */
+router.get('/', async (req, res) => {
+  const userId = req.user?.customUserId;
+
+  if (!userId) {
+    res.status(401).json({ error: 'User identity not found' });
+    return;
+  }
+
+  logger.debug('GET /installations', { userId });
+
+  try {
+    const repo = new InstallationRepository(DatabaseInstance.getInstance());
+    const installations = await repo.findByLinkedUserId(userId);
+
+    res.json(installations.map(toSummary));
+  } catch (error) {
+    logger.error('Error listing installations:', error);
+    res.status(500).json({ error: 'Failed to list installations' });
+  }
+});
+
+/**
+ * GET /installations/:id
+ * Get installation detail (owner or admin).
+ */
+router.get('/:id', async (req, res) => {
+  const { id } = req.params;
+  const userId = req.user?.customUserId;
+  const isAdmin = req.user?.role === 'admin';
+
+  logger.debug('GET /installations/:id', { id, userId });
+
+  try {
+    const repo = new InstallationRepository(DatabaseInstance.getInstance());
+    const installation = await repo.findById(id);
+
+    if (!installation) {
+      res.status(404).json({ error: 'Installation not found' });
+      return;
+    }
+
+    if (!isAdmin && installation.linkedUserId !== userId) {
+      res.status(403).json({ error: 'Access denied' });
+      return;
+    }
+
+    res.json(installation);
+  } catch (error) {
+    logger.error('Error getting installation:', error);
+    res.status(500).json({ error: 'Failed to get installation' });
+  }
+});
+
+/**
+ * DELETE /installations/:id
+ * Unlink installation from current user.
+ * Does NOT uninstall the GitHub App — that's done on GitHub.
+ */
+router.delete('/:id', async (req, res) => {
+  const { id } = req.params;
+  const userId = req.user?.customUserId;
+
+  if (!userId) {
+    res.status(401).json({ error: 'User identity not found' });
+    return;
+  }
+
+  logger.debug('DELETE /installations/:id', { id, userId });
+
+  try {
+    const repo = new InstallationRepository(DatabaseInstance.getInstance());
+    const installation = await repo.findById(id);
+
+    if (!installation) {
+      res.status(404).json({ error: 'Installation not found' });
+      return;
+    }
+
+    if (installation.linkedUserId !== userId) {
+      res.status(403).json({ error: 'Access denied' });
+      return;
+    }
+
+    await repo.unlinkUser(id);
+    res.status(204).send();
+  } catch (error) {
+    logger.error('Error unlinking installation:', error);
+    res.status(500).json({ error: 'Failed to unlink installation' });
+  }
+});
+
+/**
+ * GET /installations/admin/all
+ * Admin overview of all installations.
+ */
+router.get('/admin/all', adminMiddleware, async (req, res) => {
+  logger.debug('GET /installations/admin/all');
+
+  try {
+    const repo = new InstallationRepository(DatabaseInstance.getInstance());
+    const installations = await repo.findAll(500);
+
+    res.json(installations.map(toSummary));
+  } catch (error) {
+    logger.error('Error listing all installations:', error);
+    res.status(500).json({ error: 'Failed to list installations' });
+  }
+});
+
+function toSummary(installation: any): InstallationSummaryDto {
+  return {
+    id: installation.id,
+    accountLogin: installation.accountLogin,
+    accountType: installation.accountType,
+    repositoryCount: installation.repositories?.length ?? 0,
+    repositories: installation.repositories ?? [],
+    status: installation.status,
+    linkedUserId: installation.linkedUserId,
+    linkedAt: installation.linkedAt,
+    createdAt: installation.createdAt,
+  };
+}
+
+export { router as InstallationsController };

--- a/apps/api/src/controllers/installations-controller.ts
+++ b/apps/api/src/controllers/installations-controller.ts
@@ -67,8 +67,12 @@ router.post('/setup', validate(setupSchema), async (req, res) => {
 
         res.status(201).json(toSummary(installation));
         return;
-      } catch (fetchError) {
-        logger.error('Failed to fetch installation from GitHub', { installationId, error: fetchError });
+      } catch (fetchError: any) {
+        logger.error('Failed to fetch installation from GitHub', {
+          installationId,
+          errorMessage: fetchError?.message,
+          errorStack: fetchError?.stack,
+        });
         res.status(404).json({ error: 'Installation not found. Please try again in a moment.' });
         return;
       }

--- a/apps/api/src/controllers/installations-controller.ts
+++ b/apps/api/src/controllers/installations-controller.ts
@@ -62,13 +62,14 @@ router.post('/setup', validate(setupSchema), async (req, res) => {
             events: ghInstallation.events,
             status: 'active',
             linkedUserId: userId,
+            linkedAt: new Date().toISOString(),
           },
           String(installationId),
         );
 
-        // Grant "Connected" badge for first repo link
-        new BadgeService().grantBadge(userId, 'connected').catch((err) =>
-          logger.warn('Failed to grant connected badge', { userId, error: err?.message }),
+        // Grant onboarding badges based on total linked repos
+        grantInstallationBadges(userId, repo).catch((err) =>
+          logger.warn('Failed to grant installation badges', { userId, error: err?.message }),
         );
 
         res.status(201).json(toSummary(installation));
@@ -95,9 +96,9 @@ router.post('/setup', validate(setupSchema), async (req, res) => {
       await repo.linkToUser(installation.id, userId);
       installation.linkedUserId = userId;
 
-      // Grant "Connected" badge for first repo link
-      new BadgeService().grantBadge(userId, 'connected').catch((err) =>
-        logger.warn('Failed to grant connected badge', { userId, error: err?.message }),
+      // Grant onboarding badges based on total linked repos
+      grantInstallationBadges(userId, repo).catch((err) =>
+        logger.warn('Failed to grant installation badges', { userId, error: err?.message }),
       );
     }
 
@@ -233,6 +234,24 @@ function toSummary(installation: GitHubInstallation): InstallationSummaryDto {
     linkedAt: installation.linkedAt,
     createdAt: installation.createdAt,
   };
+}
+
+/**
+ * Grant onboarding badges based on total repos linked via GitHub App installations.
+ */
+async function grantInstallationBadges(userId: string, repo: InstanceType<typeof InstallationRepository>): Promise<void> {
+  const badgeService = new BadgeService();
+  const installations = await repo.findByLinkedUserId(userId);
+  const totalRepos = installations.reduce((sum, inst) => sum + (inst.repositories?.length ?? 0), 0);
+
+  await badgeService.grantBadge(userId, 'connected');
+
+  if (totalRepos >= 5) {
+    await badgeService.grantBadge(userId, 'fleet_commander');
+  }
+  if (totalRepos >= 10) {
+    await badgeService.grantBadge(userId, 'mission_control');
+  }
 }
 
 export { router as InstallationsController };

--- a/apps/api/src/controllers/installations-controller.ts
+++ b/apps/api/src/controllers/installations-controller.ts
@@ -4,7 +4,7 @@ import { DatabaseInstance, logger } from '@codeheroes/common';
 import { InstallationRepository } from '@codeheroes/common';
 import { GitHubAppService } from '@codeheroes/integrations';
 import { BadgeService } from '@codeheroes/progression-engine';
-import { GitHubInstallation, InstallationSummaryDto } from '@codeheroes/types';
+import { Collections, GitHubInstallation, InstallationSummaryDto } from '@codeheroes/types';
 import { validate } from '../middleware/validate.middleware';
 import { adminMiddleware } from '../middleware/admin.middleware';
 
@@ -38,51 +38,66 @@ router.post('/setup', validate(setupSchema), async (req, res) => {
     // Race condition: webhook may not have arrived yet.
     // Fetch installation details from GitHub API and create the record.
     if (!installation) {
+      let ghInstallation;
+      let ghRepos;
+
       try {
         const appService = new GitHubAppService();
-        const [ghInstallation, ghRepos] = await Promise.all([
+        [ghInstallation, ghRepos] = await Promise.all([
           appService.getInstallation(installationId),
           appService.getInstallationRepositories(installationId),
         ]);
-
-        installation = await repo.create(
-          {
-            githubInstallationId: installationId,
-            appId: ghInstallation.app_id,
-            accountLogin: ghInstallation.account.login,
-            accountId: ghInstallation.account.id,
-            accountType: ghInstallation.account.type === 'Organization' ? 'Organization' : 'User',
-            repositories: ghRepos.map((r) => ({
-              id: r.id,
-              name: r.name,
-              fullName: r.full_name,
-              private: r.private,
-            })),
-            permissions: ghInstallation.permissions,
-            events: ghInstallation.events,
-            status: 'active',
-            linkedUserId: userId,
-            linkedAt: new Date().toISOString(),
-          },
-          String(installationId),
-        );
-
-        // Grant onboarding badges based on total linked repos
-        grantInstallationBadges(userId, repo).catch((err) =>
-          logger.warn('Failed to grant installation badges', { userId, error: err?.message }),
-        );
-
-        res.status(201).json(toSummary(installation));
-        return;
       } catch (fetchError: any) {
+        const status = fetchError?.message?.includes('401') || fetchError?.message?.includes('403') ? 500 : 404;
         logger.error('Failed to fetch installation from GitHub', {
           installationId,
           errorMessage: fetchError?.message,
-          errorStack: fetchError?.stack,
         });
-        res.status(404).json({ error: 'Installation not found. Please try again in a moment.' });
+        res.status(status).json({
+          error: status === 500
+            ? 'GitHub App configuration error. Please contact support.'
+            : 'Installation not found. Please try again in a moment.',
+        });
         return;
       }
+
+      // Verify ownership: the user's GitHub account must match the installation's account
+      const ownershipValid = await verifyInstallationOwnership(userId, ghInstallation.account.login);
+      if (!ownershipValid) {
+        logger.warn('Installation ownership verification failed', { userId, accountLogin: ghInstallation.account.login });
+        res.status(403).json({ error: 'You do not have permission to link this installation' });
+        return;
+      }
+
+      installation = await repo.create(
+        {
+          githubInstallationId: installationId,
+          appId: ghInstallation.app_id,
+          accountLogin: ghInstallation.account.login,
+          accountId: ghInstallation.account.id,
+          accountType: ghInstallation.account.type === 'Organization' ? 'Organization' : 'User',
+          repositories: ghRepos.map((r) => ({
+            id: r.id,
+            name: r.name,
+            fullName: r.full_name,
+            private: r.private,
+          })),
+          permissions: ghInstallation.permissions,
+          events: ghInstallation.events,
+          status: 'active',
+          linkedUserId: userId,
+          linkedAt: new Date().toISOString(),
+        },
+        String(installationId),
+      );
+
+      // Grant onboarding badges based on total linked repos
+      grantInstallationBadges(userId, repo).catch((err) =>
+        logger.warn('Failed to grant installation badges', { userId, error: err?.message }),
+      );
+
+      res.status(201).json(toSummary(installation));
+      return;
     }
 
     // Already linked to another user
@@ -234,6 +249,30 @@ function toSummary(installation: GitHubInstallation): InstallationSummaryDto {
     linkedAt: installation.linkedAt,
     createdAt: installation.createdAt,
   };
+}
+
+/**
+ * Verify that the user has a GitHub connected account before allowing installation linking.
+ * For personal installs: username must match the installation account.
+ * For org installs: GitHub enforces org admin during install flow, so we only require
+ * that the user has a GitHub connected account (proof they're a GitHub user).
+ */
+async function verifyInstallationOwnership(userId: string, accountLogin: string): Promise<boolean> {
+  const db = DatabaseInstance.getInstance();
+  const snapshot = await db
+    .collection(Collections.Users)
+    .doc(userId)
+    .collection(Collections.ConnectedAccounts)
+    .where('provider', '==', 'github')
+    .limit(1)
+    .get();
+
+  if (snapshot.empty) {
+    logger.warn('User has no GitHub connected account', { userId });
+    return false;
+  }
+
+  return true;
 }
 
 /**

--- a/apps/api/src/controllers/installations-controller.ts
+++ b/apps/api/src/controllers/installations-controller.ts
@@ -62,7 +62,7 @@ router.post('/setup', validate(setupSchema), async (req, res) => {
       }
 
       // Verify ownership: the user's GitHub account must match the installation's account
-      const ownershipValid = await verifyInstallationOwnership(userId, ghInstallation.account.login);
+      const ownershipValid = await verifyInstallationOwnership(userId, ghInstallation.account.login, ghInstallation.account.type);
       if (!ownershipValid) {
         logger.warn('Installation ownership verification failed', { userId, accountLogin: ghInstallation.account.login });
         res.status(403).json({ error: 'You do not have permission to link this installation' });
@@ -108,6 +108,14 @@ router.post('/setup', validate(setupSchema), async (req, res) => {
 
     // Link to current user
     if (!installation.linkedUserId) {
+      // Verify ownership before linking existing installation
+      const ownershipValid = await verifyInstallationOwnership(userId, installation.accountLogin, installation.accountType);
+      if (!ownershipValid) {
+        logger.warn('Installation ownership verification failed', { userId, accountLogin: installation.accountLogin });
+        res.status(403).json({ error: 'You do not have permission to link this installation' });
+        return;
+      }
+
       await repo.linkToUser(installation.id, userId);
       installation.linkedUserId = userId;
 
@@ -252,12 +260,12 @@ function toSummary(installation: GitHubInstallation): InstallationSummaryDto {
 }
 
 /**
- * Verify that the user has a GitHub connected account before allowing installation linking.
- * For personal installs: username must match the installation account.
- * For org installs: GitHub enforces org admin during install flow, so we only require
- * that the user has a GitHub connected account (proof they're a GitHub user).
+ * Verify that the user has permission to link this installation.
+ * For personal installs (User): GitHub username must match the installation account.
+ * For org installs (Organization): GitHub enforces org admin during install flow,
+ * so we only require that the user has a GitHub connected account.
  */
-async function verifyInstallationOwnership(userId: string, accountLogin: string): Promise<boolean> {
+async function verifyInstallationOwnership(userId: string, accountLogin: string, accountType?: string): Promise<boolean> {
   const db = DatabaseInstance.getInstance();
   const snapshot = await db
     .collection(Collections.Users)
@@ -270,6 +278,19 @@ async function verifyInstallationOwnership(userId: string, accountLogin: string)
   if (snapshot.empty) {
     logger.warn('User has no GitHub connected account', { userId });
     return false;
+  }
+
+  // For personal accounts, verify the GitHub username matches
+  if (accountType === 'User') {
+    const connectedAccount = snapshot.docs[0].data();
+    if (connectedAccount.externalUserName?.toLowerCase() !== accountLogin.toLowerCase()) {
+      logger.warn('GitHub username does not match installation account', {
+        userId,
+        userGitHub: connectedAccount.externalUserName,
+        installationAccount: accountLogin,
+      });
+      return false;
+    }
   }
 
   return true;

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -13,4 +13,11 @@ import { defaultApi } from './app';
 /**
  * HTTP trigger
  * */
-export const api = onRequest({ memory: '2GiB', timeoutSeconds: 120 }, defaultApi);
+export const api = onRequest(
+  {
+    memory: '2GiB',
+    timeoutSeconds: 120,
+    secrets: ['GITHUB_APP_ID', 'GITHUB_APP_PRIVATE_KEY'],
+  },
+  defaultApi,
+);

--- a/apps/firebase-app/firestore.rules
+++ b/apps/firebase-app/firestore.rules
@@ -140,6 +140,11 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    // GitHub App installations - server processing only (admin portal reads via API)
+    match /installations/{installationId} {
+      allow read, write: if false;
+    }
+
     // ============================================
     // DENY ALL OTHER ACCESS
     // Catch-all rule for any undefined paths

--- a/apps/frontend/app/src/app/app.routes.ts
+++ b/apps/frontend/app/src/app/app.routes.ts
@@ -86,6 +86,12 @@ export const appRoutes: Routes = [
     ),
   },
   {
+    path: 'repositories',
+    loadComponent: loadWithReload(() =>
+      import('./pages/repositories/repositories.component').then((m) => m.RepositoriesComponent),
+    ),
+  },
+  {
     path: 'settings',
     loadComponent: loadWithReload(() =>
       import('./pages/settings/settings.component').then((m) => m.SettingsComponent),

--- a/apps/frontend/app/src/app/core/services/installations.service.ts
+++ b/apps/frontend/app/src/app/core/services/installations.service.ts
@@ -1,0 +1,46 @@
+import { inject, Injectable } from '@angular/core';
+import { Auth, user } from '@angular/fire/auth';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable, from, switchMap } from 'rxjs';
+import { InstallationSummaryDto } from '@codeheroes/types';
+import { environment } from '../../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class InstallationsService {
+  readonly #auth = inject(Auth);
+  readonly #http = inject(HttpClient);
+  readonly #authUser$ = user(this.#auth);
+
+  #withAuth<T>(fn: (headers: HttpHeaders) => Observable<T>): Observable<T> {
+    return this.#authUser$.pipe(
+      switchMap((authUser) => {
+        if (!authUser) throw new Error('Not authenticated');
+        return from(authUser.getIdToken()).pipe(
+          switchMap((token) => fn(new HttpHeaders().set('Authorization', `Bearer ${token}`))),
+        );
+      }),
+    );
+  }
+
+  getInstallations(): Observable<InstallationSummaryDto[]> {
+    return this.#withAuth((headers) =>
+      this.#http.get<InstallationSummaryDto[]>(`${environment.apiUrl}/installations`, { headers }),
+    );
+  }
+
+  setupInstallation(installationId: number, setupAction: string): Observable<InstallationSummaryDto> {
+    return this.#withAuth((headers) =>
+      this.#http.post<InstallationSummaryDto>(
+        `${environment.apiUrl}/installations/setup`,
+        { installationId, setupAction },
+        { headers },
+      ),
+    );
+  }
+
+  unlinkInstallation(id: string): Observable<void> {
+    return this.#withAuth((headers) =>
+      this.#http.delete<void>(`${environment.apiUrl}/installations/${id}`, { headers }),
+    );
+  }
+}

--- a/apps/frontend/app/src/app/pages/repositories/repositories.component.ts
+++ b/apps/frontend/app/src/app/pages/repositories/repositories.component.ts
@@ -142,7 +142,7 @@ import { environment } from '../../../environments/environment';
         height: 48px;
         color: rgba(255, 255, 255, 0.5);
       }
-      .github-icon-large :global(svg) { width: 48px; height: 48px; }
+      .github-icon-large svg { width: 48px; height: 48px; }
 
       .error-icon {
         width: 48px;

--- a/apps/frontend/app/src/app/pages/repositories/repositories.component.ts
+++ b/apps/frontend/app/src/app/pages/repositories/repositories.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, signal, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { InstallationSummaryDto } from '@codeheroes/types';
@@ -301,7 +301,6 @@ import { environment } from '../../../environments/environment';
 })
 export class RepositoriesComponent implements OnInit, OnDestroy {
   readonly #route = inject(ActivatedRoute);
-  readonly #router = inject(Router);
   readonly #location = inject(Location);
   readonly #installationsService = inject(InstallationsService);
 
@@ -364,8 +363,8 @@ export class RepositoriesComponent implements OnInit, OnDestroy {
     this.isSettingUp.set(true);
     this.isLoading.set(false);
 
-    // Clear query params from URL
-    this.#router.navigate([], { queryParams: {}, replaceUrl: true });
+    // Clear query params from URL without navigating away from current route
+    this.#location.replaceState(this.#location.path().split('?')[0]);
 
     this.#sub = this.#installationsService.setupInstallation(installationId, setupAction).subscribe({
       next: () => {

--- a/apps/frontend/app/src/app/pages/repositories/repositories.component.ts
+++ b/apps/frontend/app/src/app/pages/repositories/repositories.component.ts
@@ -309,8 +309,7 @@ export class RepositoriesComponent implements OnInit, OnDestroy {
   isSettingUp = signal(false);
   setupError = signal<string | null>(null);
 
-  // TODO: Replace with actual GitHub App slug after creation
-  readonly installUrl = `https://github.com/apps/${environment.githubAppSlug ?? 'code-heroes-test'}/installations/new`;
+  readonly installUrl = `https://github.com/apps/${environment.githubAppSlug}/installations/new`;
 
   readonly githubIcon = `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>`;
 

--- a/apps/frontend/app/src/app/pages/repositories/repositories.component.ts
+++ b/apps/frontend/app/src/app/pages/repositories/repositories.component.ts
@@ -1,0 +1,385 @@
+import { Component, inject, signal, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Location } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { InstallationSummaryDto } from '@codeheroes/types';
+import { InstallationsService } from '../../core/services/installations.service';
+import { environment } from '../../../environments/environment';
+
+@Component({
+  selector: 'app-repositories',
+  standalone: true,
+  template: `
+    <!-- Header -->
+    <header class="sticky top-0 z-20 bg-black/90 backdrop-blur-sm px-4 py-4 md:px-6 lg:px-8 md:py-5">
+      <div class="flex items-center gap-3 relative z-10">
+        <button type="button" (click)="goBack()" aria-label="Back" class="back-button">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <h1 class="text-2xl md:text-4xl font-bold italic text-white">Repositories</h1>
+      </div>
+    </header>
+
+    <!-- Main Content -->
+    <main class="relative z-10 px-4 md:px-6 lg:px-8 pb-24">
+      <div class="max-w-2xl mx-auto py-8">
+
+        @if (isLoading()) {
+          <div class="flex items-center justify-center py-20">
+            <div class="text-xl text-purple-400/70 animate-pulse" role="status" aria-live="polite">Loading...</div>
+          </div>
+        } @else if (isSettingUp()) {
+          <div class="flex flex-col items-center justify-center py-20 gap-4">
+            <div class="text-xl text-purple-400/70 animate-pulse">Setting up...</div>
+            <p class="text-sm text-white/40">Linking your GitHub installation</p>
+          </div>
+        } @else if (setupError()) {
+          <section class="content-section">
+            <div class="flex flex-col items-center text-center gap-4 py-8">
+              <div class="error-icon">!</div>
+              <h2 class="text-lg font-semibold text-white">Setup Failed</h2>
+              <p class="text-sm text-white/50 max-w-sm">{{ setupError() }}</p>
+              <button type="button" class="action-button" (click)="loadInstallations()">Try Again</button>
+            </div>
+          </section>
+        } @else if (installations().length === 0) {
+          <!-- Empty state: no installations -->
+          <section class="content-section">
+            <div class="flex flex-col items-center text-center gap-5 py-8">
+              <div class="github-icon-large" [innerHTML]="githubIcon"></div>
+              <h2 class="text-xl font-bold text-white">Connect your repositories</h2>
+              <p class="text-sm text-white/50 max-w-sm leading-relaxed">
+                Install the Code Heroes GitHub App to track your coding activity.
+                You choose which repos — we only read events, never your code.
+              </p>
+              <a [href]="installUrl" class="action-button" target="_blank" rel="noopener noreferrer">
+                Install on GitHub
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+            </div>
+          </section>
+        } @else {
+          <!-- Installations list -->
+          @for (installation of installations(); track installation.id) {
+            <section class="content-section installation-card">
+              <div class="installation-header">
+                <div class="installation-account">
+                  <span class="account-name">{{ installation.accountLogin }}</span>
+                  <span class="account-type">{{ installation.accountType }}</span>
+                </div>
+                <span class="status-badge" [class]="'status-' + installation.status">
+                  {{ installation.status }}
+                </span>
+              </div>
+
+              @if (installation.repositories.length === 0) {
+                <p class="text-sm text-white/40 py-2">No repositories selected</p>
+              } @else {
+                <div class="repo-list">
+                  @for (repo of installation.repositories; track repo.id) {
+                    <div class="repo-row">
+                      <span class="repo-name">{{ repo.name }}</span>
+                      @if (repo.private) {
+                        <span class="repo-private">private</span>
+                      }
+                    </div>
+                  }
+                </div>
+              }
+
+              <div class="installation-actions">
+                <a [href]="getManageUrl(installation)" class="link-button" target="_blank" rel="noopener noreferrer">
+                  Manage on GitHub
+                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                </a>
+              </div>
+            </section>
+          }
+
+          <a [href]="installUrl" class="add-more-button" target="_blank" rel="noopener noreferrer">
+            + Add more repositories
+          </a>
+        }
+      </div>
+    </main>
+  `,
+  styles: [
+    `
+      :host { display: block; }
+
+      .back-button {
+        background: transparent;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 6px;
+        padding: 0.5rem;
+        min-width: 40px;
+        min-height: 40px;
+        color: rgba(255, 255, 255, 0.6);
+        cursor: pointer;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .back-button:hover { color: white; border-color: rgba(255, 255, 255, 0.4); }
+
+      .content-section {
+        background: rgba(0, 0, 0, 0.3);
+        border: 1px solid rgba(139, 92, 246, 0.2);
+        border-radius: 16px;
+        padding: 1.5rem;
+        margin-bottom: 1rem;
+      }
+
+      .github-icon-large {
+        width: 48px;
+        height: 48px;
+        color: rgba(255, 255, 255, 0.5);
+      }
+      .github-icon-large :global(svg) { width: 48px; height: 48px; }
+
+      .error-icon {
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        background: rgba(239, 68, 68, 0.15);
+        border: 1px solid rgba(239, 68, 68, 0.3);
+        color: rgb(239, 68, 68);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.5rem;
+        font-weight: 700;
+      }
+
+      .action-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.75rem 1.5rem;
+        border-radius: 10px;
+        border: none;
+        background: linear-gradient(135deg, rgb(6, 182, 212), rgb(139, 92, 246));
+        color: white;
+        font-size: 0.9375rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.2s;
+        text-decoration: none;
+      }
+      .action-button:hover { box-shadow: 0 0 24px rgba(6, 182, 212, 0.3); }
+
+      .installation-card { margin-bottom: 1rem; }
+
+      .installation-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 1rem;
+      }
+
+      .installation-account {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .account-name {
+        font-size: 1rem;
+        font-weight: 600;
+        color: white;
+      }
+
+      .account-type {
+        font-size: 0.6875rem;
+        color: rgba(255, 255, 255, 0.4);
+        background: rgba(255, 255, 255, 0.05);
+        padding: 0.125rem 0.5rem;
+        border-radius: 4px;
+        text-transform: lowercase;
+      }
+
+      .status-badge {
+        font-size: 0.6875rem;
+        font-weight: 600;
+        padding: 0.25rem 0.625rem;
+        border-radius: 9999px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .status-active {
+        color: rgb(34, 197, 94);
+        background: rgba(34, 197, 94, 0.1);
+        border: 1px solid rgba(34, 197, 94, 0.3);
+      }
+      .status-suspended {
+        color: rgb(234, 179, 8);
+        background: rgba(234, 179, 8, 0.1);
+        border: 1px solid rgba(234, 179, 8, 0.3);
+      }
+      .status-deleted {
+        color: rgb(239, 68, 68);
+        background: rgba(239, 68, 68, 0.1);
+        border: 1px solid rgba(239, 68, 68, 0.3);
+      }
+
+      .repo-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+      }
+
+      .repo-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem 0.75rem;
+        background: rgba(255, 255, 255, 0.03);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+        border-radius: 8px;
+      }
+
+      .repo-name {
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: rgba(255, 255, 255, 0.85);
+        font-family: monospace;
+      }
+
+      .repo-private {
+        font-size: 0.625rem;
+        color: rgba(255, 255, 255, 0.35);
+        background: rgba(255, 255, 255, 0.05);
+        padding: 0.0625rem 0.375rem;
+        border-radius: 4px;
+      }
+
+      .installation-actions {
+        display: flex;
+        gap: 0.75rem;
+        margin-top: 1rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.05);
+      }
+
+      .link-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        font-size: 0.8125rem;
+        color: var(--neon-cyan, rgb(6, 182, 212));
+        text-decoration: none;
+        transition: opacity 0.2s;
+      }
+      .link-button:hover { opacity: 0.8; }
+
+      .add-more-button {
+        display: block;
+        text-align: center;
+        padding: 0.875rem;
+        border: 1px dashed rgba(139, 92, 246, 0.3);
+        border-radius: 12px;
+        color: rgba(139, 92, 246, 0.7);
+        font-size: 0.875rem;
+        font-weight: 500;
+        text-decoration: none;
+        transition: all 0.2s;
+      }
+      .add-more-button:hover {
+        border-color: rgba(6, 182, 212, 0.5);
+        color: var(--neon-cyan, rgb(6, 182, 212));
+        background: rgba(6, 182, 212, 0.05);
+      }
+    `,
+  ],
+})
+export class RepositoriesComponent implements OnInit, OnDestroy {
+  readonly #route = inject(ActivatedRoute);
+  readonly #router = inject(Router);
+  readonly #location = inject(Location);
+  readonly #installationsService = inject(InstallationsService);
+
+  installations = signal<InstallationSummaryDto[]>([]);
+  isLoading = signal(true);
+  isSettingUp = signal(false);
+  setupError = signal<string | null>(null);
+
+  // TODO: Replace with actual GitHub App slug after creation
+  readonly installUrl = `https://github.com/apps/${environment.githubAppSlug ?? 'code-heroes-test'}/installations/new`;
+
+  readonly githubIcon = `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>`;
+
+  #sub: Subscription | null = null;
+
+  ngOnInit() {
+    // Check for GitHub redirect params
+    const params = this.#route.snapshot.queryParams;
+    const installationId = params['installation_id'];
+    const setupAction = params['setup_action'];
+
+    if (installationId && setupAction) {
+      this.#setupInstallation(Number(installationId), setupAction);
+    } else {
+      this.loadInstallations();
+    }
+  }
+
+  ngOnDestroy() {
+    this.#sub?.unsubscribe();
+  }
+
+  loadInstallations() {
+    this.isLoading.set(true);
+    this.setupError.set(null);
+    this.#sub?.unsubscribe();
+
+    this.#sub = this.#installationsService.getInstallations().subscribe({
+      next: (installations) => {
+        this.installations.set(installations);
+        this.isLoading.set(false);
+      },
+      error: (error) => {
+        console.error('Failed to load installations:', error);
+        this.installations.set([]);
+        this.isLoading.set(false);
+      },
+    });
+  }
+
+  getManageUrl(installation: InstallationSummaryDto): string {
+    return `https://github.com/settings/installations/${installation.id}`;
+  }
+
+  goBack() {
+    this.#location.back();
+  }
+
+  #setupInstallation(installationId: number, setupAction: string) {
+    this.isSettingUp.set(true);
+    this.isLoading.set(false);
+
+    // Clear query params from URL
+    this.#router.navigate([], { queryParams: {}, replaceUrl: true });
+
+    this.#sub = this.#installationsService.setupInstallation(installationId, setupAction).subscribe({
+      next: () => {
+        this.isSettingUp.set(false);
+        this.loadInstallations();
+      },
+      error: (error) => {
+        this.isSettingUp.set(false);
+        const message =
+          error?.error?.error === 'This installation is already linked to another account'
+            ? 'This installation is already linked to another account.'
+            : 'Failed to set up installation. Please try again.';
+        this.setupError.set(message);
+      },
+    });
+  }
+}

--- a/apps/frontend/app/src/app/pages/settings/settings.component.ts
+++ b/apps/frontend/app/src/app/pages/settings/settings.component.ts
@@ -1,5 +1,6 @@
 import { Component, inject, signal, OnInit, OnDestroy, Injector, runInInjectionContext } from '@angular/core';
 import { DecimalPipe, Location } from '@angular/common';
+import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { Firestore, collection, collectionData } from '@angular/fire/firestore';
@@ -15,7 +16,7 @@ const GOAL_PRESETS = [4000, 8000, 12000, 16000];
 @Component({
   selector: 'app-settings',
   standalone: true,
-  imports: [DecimalPipe, FormsModule, ConnectedAccountsComponent],
+  imports: [DecimalPipe, FormsModule, RouterLink, ConnectedAccountsComponent],
   template: `
     <!-- Header -->
     <header class="sticky top-0 z-20 bg-black/90 backdrop-blur-sm px-4 py-4 md:px-6 lg:px-8 md:py-5">
@@ -125,6 +126,21 @@ const GOAL_PRESETS = [4000, 8000, 12000, 16000];
             <h2 class="section-title">Connected Accounts</h2>
             <p class="section-description">Accounts linked to your profile</p>
             <app-connected-accounts [accounts]="connectedAccounts()" [showTitle]="false" />
+          </section>
+
+          <!-- Repositories Section -->
+          <section class="settings-section">
+            <h2 class="section-title">My Repositories</h2>
+            <p class="section-description">Manage which repos track your activity</p>
+            <a routerLink="/repositories" class="link-row">
+              <svg class="link-row-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
+              </svg>
+              <span class="link-row-text">Manage Repositories</span>
+              <svg class="link-row-chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </a>
           </section>
 
           <!-- Account Section -->

--- a/apps/frontend/app/src/environments/environment.interface.ts
+++ b/apps/frontend/app/src/environments/environment.interface.ts
@@ -16,7 +16,7 @@ export interface Environment {
   };
   appVersion: string;
   vapidKey?: string;
-  githubAppSlug?: string;
+  githubAppSlug: string;
   autoLogin?: {
     email: string;
     password: string;

--- a/apps/frontend/app/src/environments/environment.interface.ts
+++ b/apps/frontend/app/src/environments/environment.interface.ts
@@ -16,6 +16,7 @@ export interface Environment {
   };
   appVersion: string;
   vapidKey?: string;
+  githubAppSlug?: string;
   autoLogin?: {
     email: string;
     password: string;

--- a/apps/frontend/app/src/environments/environment.local.ts.template
+++ b/apps/frontend/app/src/environments/environment.local.ts.template
@@ -13,5 +13,6 @@ export const environment: Environment = {
     appId: '${FIREBASE_APP_ID}',
   },
   appVersion: '${APP_VERSION}',
+  githubAppSlug: 'code-heroes-test',
   vapidKey: '${FIREBASE_VAPID_KEY}',
 };

--- a/apps/frontend/app/src/environments/environment.prod.ts.template
+++ b/apps/frontend/app/src/environments/environment.prod.ts.template
@@ -14,5 +14,6 @@ export const environment: Environment = {
     measurementId: '${FIREBASE_PROD_MEASUREMENT_ID}',
   },
   appVersion: '${APP_VERSION}',
+  githubAppSlug: 'code-heroes',
   vapidKey: '${FIREBASE_PROD_VAPID_KEY}',
 };

--- a/apps/frontend/app/src/environments/environment.test.ts.template
+++ b/apps/frontend/app/src/environments/environment.test.ts.template
@@ -14,5 +14,6 @@ export const environment: Environment = {
     measurementId: '${FIREBASE_TEST_MEASUREMENT_ID}',
   },
   appVersion: '${APP_VERSION}',
+  githubAppSlug: 'code-heroes-test',
   vapidKey: '${FIREBASE_TEST_VAPID_KEY}',
 };

--- a/apps/frontend/app/src/environments/environment.ts
+++ b/apps/frontend/app/src/environments/environment.ts
@@ -13,5 +13,6 @@ export const environment: Environment = {
     appId: '',
   },
   appVersion: 'dev',
+  githubAppSlug: 'code-heroes-test',
   vapidKey: '',
 };

--- a/apps/github-receiver/src/app.ts
+++ b/apps/github-receiver/src/app.ts
@@ -2,10 +2,17 @@ import { Request, Response } from 'express';
 import { processWebhook } from '@codeheroes/integrations';
 
 export const App = async (req: Request, res: Response): Promise<void> => {
+  // GitHub App webhooks include an `installation` object in the payload.
+  // Use the app-specific secret for those, legacy secret for manual webhooks.
+  const isAppWebhook = req.body?.installation != null;
+  const secret = isAppWebhook
+    ? process.env.GITHUB_APP_WEBHOOK_SECRET
+    : process.env.WEBHOOK_SECRET;
+
   return processWebhook({
     req,
     res,
     provider: 'github',
-    secret: process.env.WEBHOOK_SECRET,
+    secret,
   });
 };

--- a/apps/github-receiver/src/main.ts
+++ b/apps/github-receiver/src/main.ts
@@ -11,7 +11,7 @@ setGlobalOptions({ region: DEFAULT_REGION, memory: '2GiB' });
 
 export const gitHubReceiver = onRequest(
   {
-    secrets: ['WEBHOOK_SECRET', 'GITHUB_APP_WEBHOOK_SECRET'],
+    secrets: ['GITHUB_APP_WEBHOOK_SECRET'],
   },
   App,
 );

--- a/apps/github-receiver/src/main.ts
+++ b/apps/github-receiver/src/main.ts
@@ -9,4 +9,9 @@ import { App } from './app';
 
 setGlobalOptions({ region: DEFAULT_REGION, memory: '2GiB' });
 
-export const gitHubReceiver = onRequest(App);
+export const gitHubReceiver = onRequest(
+  {
+    secrets: ['WEBHOOK_SECRET', 'GITHUB_APP_WEBHOOK_SECRET'],
+  },
+  App,
+);

--- a/libs/server/common/src/core/repository/index.ts
+++ b/libs/server/common/src/core/repository/index.ts
@@ -1,3 +1,4 @@
 export * from './base-repository';
 export * from './repository.interface';
+export * from './installation.repository';
 export * from './unmatched-event.repository';

--- a/libs/server/common/src/core/repository/installation.repository.ts
+++ b/libs/server/common/src/core/repository/installation.repository.ts
@@ -1,4 +1,4 @@
-import { Firestore } from 'firebase-admin/firestore';
+import { FieldValue, Firestore } from 'firebase-admin/firestore';
 import { Collections, GitHubInstallation, InstallationRepository as InstallationRepo } from '@codeheroes/types';
 import { BaseRepository } from './base-repository';
 import { getCurrentTimeAsISO } from '../firebase/time.utils';
@@ -35,12 +35,11 @@ export class InstallationRepository extends BaseRepository<GitHubInstallation> {
   }
 
   async unlinkUser(installationId: string): Promise<void> {
-    const now = getCurrentTimeAsISO();
     const docRef = this.getDocRef(installationId);
     await docRef.update({
-      linkedUserId: null,
-      linkedAt: null,
-      updatedAt: now,
+      linkedUserId: FieldValue.delete(),
+      linkedAt: FieldValue.delete(),
+      updatedAt: getCurrentTimeAsISO(),
     });
   }
 

--- a/libs/server/common/src/core/repository/installation.repository.ts
+++ b/libs/server/common/src/core/repository/installation.repository.ts
@@ -1,0 +1,56 @@
+import { Firestore } from 'firebase-admin/firestore';
+import { Collections, GitHubInstallation, InstallationRepository as InstallationRepo } from '@codeheroes/types';
+import { BaseRepository } from './base-repository';
+import { getCurrentTimeAsISO } from '../firebase/time.utils';
+
+export class InstallationRepository extends BaseRepository<GitHubInstallation> {
+  protected collectionPath = Collections.Installations;
+
+  constructor(db: Firestore) {
+    super(db);
+  }
+
+  async findByGithubInstallationId(githubInstallationId: number): Promise<GitHubInstallation | null> {
+    const results = await this.findWhere('githubInstallationId', '==', githubInstallationId, 1);
+    return results[0] ?? null;
+  }
+
+  async findByLinkedUserId(userId: string): Promise<GitHubInstallation[]> {
+    return this.findWhere('linkedUserId', '==', userId);
+  }
+
+  async findByAccountLogin(login: string): Promise<GitHubInstallation[]> {
+    return this.findWhere('accountLogin', '==', login);
+  }
+
+  async findActive(): Promise<GitHubInstallation[]> {
+    return this.findWhere('status', '==', 'active');
+  }
+
+  async linkToUser(installationId: string, userId: string): Promise<void> {
+    await this.update(installationId, {
+      linkedUserId: userId,
+      linkedAt: getCurrentTimeAsISO(),
+    } as Partial<GitHubInstallation>);
+  }
+
+  async unlinkUser(installationId: string): Promise<void> {
+    const now = getCurrentTimeAsISO();
+    const docRef = this.getDocRef(installationId);
+    await docRef.update({
+      linkedUserId: null,
+      linkedAt: null,
+      updatedAt: now,
+    });
+  }
+
+  async updateRepositories(installationId: string, repos: InstallationRepo[]): Promise<void> {
+    await this.update(installationId, {
+      repositories: repos,
+    } as Partial<GitHubInstallation>);
+  }
+
+  async updateStatus(installationId: string, status: GitHubInstallation['status']): Promise<void> {
+    await this.update(installationId, { status } as Partial<GitHubInstallation>);
+  }
+}

--- a/libs/server/integrations/src/lib/index.ts
+++ b/libs/server/integrations/src/lib/index.ts
@@ -4,5 +4,7 @@ export * from './providers/github/github.adapter';
 export * from './providers/azure-devops/adapter';
 export * from './providers/bitbucket/adapter';
 export * from './services/game-action.service';
+export * from './services/github-app.service';
+export * from './services/installation-event.handler';
 export * from './webhook/webhook-pipeline';
 export * from './webhook/webhook-event.types';

--- a/libs/server/integrations/src/lib/services/github-app.service.ts
+++ b/libs/server/integrations/src/lib/services/github-app.service.ts
@@ -1,0 +1,135 @@
+import * as jwt from 'jsonwebtoken';
+import { logger } from '@codeheroes/common';
+
+interface InstallationAccessToken {
+  token: string;
+  expiresAt: string;
+}
+
+export class GitHubAppService {
+  readonly #appId: string;
+  readonly #privateKey: string;
+
+  constructor() {
+    const appId = process.env.GITHUB_APP_ID;
+    const privateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+
+    if (!appId || !privateKey) {
+      throw new Error('GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY environment variables are required');
+    }
+
+    this.#appId = appId;
+    // Private key may be stored with escaped newlines in env vars
+    this.#privateKey = privateKey.replace(/\\n/g, '\n');
+  }
+
+  /**
+   * Generate a JWT for authenticating as the GitHub App.
+   * Valid for 10 minutes (GitHub maximum).
+   */
+  generateJwt(): string {
+    const now = Math.floor(Date.now() / 1000);
+
+    return jwt.sign(
+      {
+        iat: now - 60, // 60 seconds in the past to account for clock drift
+        exp: now + 600, // 10 minutes
+        iss: this.#appId,
+      },
+      this.#privateKey,
+      { algorithm: 'RS256' },
+    );
+  }
+
+  /**
+   * Get a short-lived installation access token for making API calls
+   * on behalf of a specific installation.
+   */
+  async getInstallationAccessToken(installationId: number): Promise<InstallationAccessToken> {
+    const appJwt = this.generateJwt();
+
+    const response = await fetch(
+      `https://api.github.com/app/installations/${installationId}/access_tokens`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${appJwt}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      logger.error('Failed to get installation access token', { installationId, status: response.status, error });
+      throw new Error(`Failed to get installation access token: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return {
+      token: data.token,
+      expiresAt: data.expires_at,
+    };
+  }
+
+  /**
+   * Get the list of repositories accessible to an installation.
+   * Useful when the installation webhook hasn't arrived yet (race condition on setup).
+   */
+  async getInstallation(installationId: number): Promise<{
+    id: number;
+    account: { login: string; id: number; type: string };
+    permissions: Record<string, string>;
+    events: string[];
+  }> {
+    const appJwt = this.generateJwt();
+
+    const response = await fetch(
+      `https://api.github.com/app/installations/${installationId}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${appJwt}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      logger.error('Failed to get installation', { installationId, status: response.status, error });
+      throw new Error(`Failed to get installation: ${response.status}`);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Get repositories for an installation using an installation access token.
+   */
+  async getInstallationRepositories(installationId: number): Promise<
+    Array<{ id: number; name: string; full_name: string; private: boolean }>
+  > {
+    const { token } = await this.getInstallationAccessToken(installationId);
+
+    const response = await fetch('https://api.github.com/installation/repositories?per_page=100', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      logger.error('Failed to get installation repositories', { installationId, status: response.status, error });
+      throw new Error(`Failed to get installation repositories: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return data.repositories;
+  }
+}

--- a/libs/server/integrations/src/lib/services/github-app.service.ts
+++ b/libs/server/integrations/src/lib/services/github-app.service.ts
@@ -134,10 +134,11 @@ export class GitHubAppService {
   > {
     const { token } = await this.getInstallationAccessToken(installationId);
     const perPage = 100;
+    const maxPages = 50;
     let page = 1;
     const repositories: Array<{ id: number; name: string; full_name: string; private: boolean }> = [];
 
-    while (true) {
+    while (page <= maxPages) {
       const response = await fetch(
         `https://api.github.com/installation/repositories?per_page=${perPage}&page=${page}`,
         {
@@ -164,6 +165,10 @@ export class GitHubAppService {
         break;
       }
       page += 1;
+    }
+
+    if (page > maxPages) {
+      logger.warn('Reached pagination cap for installation repositories', { installationId, fetched: repositories.length, maxPages });
     }
 
     return repositories;

--- a/libs/server/integrations/src/lib/services/github-app.service.ts
+++ b/libs/server/integrations/src/lib/services/github-app.service.ts
@@ -1,4 +1,4 @@
-import * as jwt from 'jsonwebtoken';
+import { sign as jwtSign } from 'jsonwebtoken';
 import { logger } from '@codeheroes/common';
 
 interface InstallationAccessToken {
@@ -18,9 +18,9 @@ export class GitHubAppService {
       throw new Error('GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY environment variables are required');
     }
 
-    this.#appId = appId;
+    this.#appId = appId.trim();
     // Private key may be stored with escaped newlines in env vars
-    this.#privateKey = privateKey.replace(/\\n/g, '\n');
+    this.#privateKey = privateKey.replace(/\\n/g, '\n').trim();
   }
 
   /**
@@ -31,7 +31,7 @@ export class GitHubAppService {
     const now = Math.floor(Date.now() / 1000);
 
     try {
-      return jwt.sign(
+      return jwtSign(
         {
           iat: now - 60, // 60 seconds in the past to account for clock drift
           exp: now + 600, // 10 minutes

--- a/libs/server/integrations/src/lib/services/github-app.service.ts
+++ b/libs/server/integrations/src/lib/services/github-app.service.ts
@@ -30,15 +30,25 @@ export class GitHubAppService {
   generateJwt(): string {
     const now = Math.floor(Date.now() / 1000);
 
-    return jwt.sign(
-      {
-        iat: now - 60, // 60 seconds in the past to account for clock drift
-        exp: now + 600, // 10 minutes
-        iss: this.#appId,
-      },
-      this.#privateKey,
-      { algorithm: 'RS256' },
-    );
+    try {
+      return jwt.sign(
+        {
+          iat: now - 60, // 60 seconds in the past to account for clock drift
+          exp: now + 600, // 10 minutes
+          iss: this.#appId,
+        },
+        this.#privateKey,
+        { algorithm: 'RS256' },
+      );
+    } catch (error: any) {
+      logger.error('Failed to generate GitHub App JWT', {
+        appId: this.#appId,
+        keyLength: this.#privateKey?.length,
+        keyStart: this.#privateKey?.substring(0, 30),
+        errorMessage: error?.message,
+      });
+      throw error;
+    }
   }
 
   /**

--- a/libs/server/integrations/src/lib/services/github-app.service.ts
+++ b/libs/server/integrations/src/lib/services/github-app.service.ts
@@ -54,7 +54,6 @@ export class GitHubAppService {
       logger.error('Failed to generate GitHub App JWT', {
         appId: this.#appId,
         keyLength: this.#privateKey?.length,
-        keyStart: this.#privateKey?.substring(0, 30),
         errorMessage: error?.message,
       });
       throw error;
@@ -99,6 +98,7 @@ export class GitHubAppService {
    */
   async getInstallation(installationId: number): Promise<{
     id: number;
+    app_id: number;
     account: { login: string; id: number; type: string };
     permissions: Record<string, string>;
     events: string[];

--- a/libs/server/integrations/src/lib/services/github-app.service.ts
+++ b/libs/server/integrations/src/lib/services/github-app.service.ts
@@ -133,23 +133,39 @@ export class GitHubAppService {
     Array<{ id: number; name: string; full_name: string; private: boolean }>
   > {
     const { token } = await this.getInstallationAccessToken(installationId);
+    const perPage = 100;
+    let page = 1;
+    const repositories: Array<{ id: number; name: string; full_name: string; private: boolean }> = [];
 
-    const response = await fetch('https://api.github.com/installation/repositories?per_page=100', {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-    });
+    while (true) {
+      const response = await fetch(
+        `https://api.github.com/installation/repositories?per_page=${perPage}&page=${page}`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+        },
+      );
 
-    if (!response.ok) {
-      const error = await response.text();
-      logger.error('Failed to get installation repositories', { installationId, status: response.status, error });
-      throw new Error(`Failed to get installation repositories: ${response.status}`);
+      if (!response.ok) {
+        const error = await response.text();
+        logger.error('Failed to get installation repositories', { installationId, page, status: response.status, error });
+        throw new Error(`Failed to get installation repositories: ${response.status}`);
+      }
+
+      const data: { total_count?: number; repositories: Array<{ id: number; name: string; full_name: string; private: boolean }> } =
+        await response.json();
+      repositories.push(...data.repositories);
+
+      if (data.repositories.length < perPage || (typeof data.total_count === 'number' && repositories.length >= data.total_count)) {
+        break;
+      }
+      page += 1;
     }
 
-    const data = await response.json();
-    return data.repositories;
+    return repositories;
   }
 }

--- a/libs/server/integrations/src/lib/services/github-app.service.ts
+++ b/libs/server/integrations/src/lib/services/github-app.service.ts
@@ -1,4 +1,4 @@
-import { sign as jwtSign } from 'jsonwebtoken';
+import { createSign } from 'crypto';
 import { logger } from '@codeheroes/common';
 
 interface InstallationAccessToken {
@@ -31,15 +31,25 @@ export class GitHubAppService {
     const now = Math.floor(Date.now() / 1000);
 
     try {
-      return jwtSign(
-        {
-          iat: now - 60, // 60 seconds in the past to account for clock drift
-          exp: now + 600, // 10 minutes
-          iss: this.#appId,
-        },
-        this.#privateKey,
-        { algorithm: 'RS256' },
-      );
+      const header = { alg: 'RS256', typ: 'JWT' };
+      const payload = {
+        iat: now - 60,
+        exp: now + 600,
+        iss: this.#appId,
+      };
+
+      const encode = (obj: object) =>
+        Buffer.from(JSON.stringify(obj)).toString('base64url');
+
+      const headerB64 = encode(header);
+      const payloadB64 = encode(payload);
+      const signingInput = `${headerB64}.${payloadB64}`;
+
+      const signer = createSign('RSA-SHA256');
+      signer.update(signingInput);
+      const signature = signer.sign(this.#privateKey, 'base64url');
+
+      return `${signingInput}.${signature}`;
     } catch (error: any) {
       logger.error('Failed to generate GitHub App JWT', {
         appId: this.#appId,

--- a/libs/server/integrations/src/lib/services/installation-event.handler.ts
+++ b/libs/server/integrations/src/lib/services/installation-event.handler.ts
@@ -41,8 +41,20 @@ export class InstallationEventHandler {
           status: 'active',
         };
 
-        await this.#repo.create(data, installationId);
-        logger.info('Installation created', { installationId, account: installation.account.login, repoCount: repos.length });
+        // Idempotent: if doc already exists (race with /installations/setup), merge without overwriting linkedUserId
+        const existing = await this.#repo.findById(installationId);
+        if (existing) {
+          await this.#repo.update(installationId, {
+            repositories: repos,
+            permissions: installation.permissions || {},
+            events: installation.events || [],
+            status: 'active',
+          } as Partial<GitHubInstallation>);
+          logger.info('Installation created event merged into existing doc', { installationId, account: installation.account.login, repoCount: repos.length });
+        } else {
+          await this.#repo.create(data, installationId);
+          logger.info('Installation created', { installationId, account: installation.account.login, repoCount: repos.length });
+        }
         break;
       }
 

--- a/libs/server/integrations/src/lib/services/installation-event.handler.ts
+++ b/libs/server/integrations/src/lib/services/installation-event.handler.ts
@@ -21,9 +21,15 @@ export class InstallationEventHandler {
 
   async #handleInstallation(payload: any): Promise<void> {
     const { action, installation, repositories } = payload;
+
+    if (!installation?.id || !installation?.account?.login) {
+      logger.error('Malformed installation event: missing installation.id or installation.account.login', { action });
+      return;
+    }
+
     const installationId = String(installation.id);
 
-    logger.info('Handling installation event', { action, installationId: installation.id, account: installation.account?.login });
+    logger.info('Handling installation event', { action, installationId: installation.id, account: installation.account.login });
 
     switch (action) {
       case 'created': {

--- a/libs/server/integrations/src/lib/services/installation-event.handler.ts
+++ b/libs/server/integrations/src/lib/services/installation-event.handler.ts
@@ -101,7 +101,12 @@ export class InstallationEventHandler {
 
     if (action === 'added' && repositories_added) {
       const newRepos: InstallationRepo[] = repositories_added.map(this.#mapRepository);
-      updatedRepos = [...updatedRepos, ...newRepos];
+      // De-duplicate by repo ID to handle webhook retries
+      const reposById = new Map(updatedRepos.map((r) => [r.id, r]));
+      for (const repo of newRepos) {
+        reposById.set(repo.id, repo);
+      }
+      updatedRepos = Array.from(reposById.values());
     }
 
     if (action === 'removed' && repositories_removed) {

--- a/libs/server/integrations/src/lib/services/installation-event.handler.ts
+++ b/libs/server/integrations/src/lib/services/installation-event.handler.ts
@@ -1,0 +1,120 @@
+import { InstallationRepository } from '@codeheroes/common';
+import { GitHubInstallation, InstallationRepository as InstallationRepo } from '@codeheroes/types';
+import { DatabaseInstance, logger } from '@codeheroes/common';
+
+export class InstallationEventHandler {
+  readonly #repo: InstallationRepository;
+
+  constructor() {
+    this.#repo = new InstallationRepository(DatabaseInstance.getInstance());
+  }
+
+  async handle(eventType: string, payload: any): Promise<void> {
+    if (eventType === 'installation') {
+      await this.#handleInstallation(payload);
+    } else if (eventType === 'installation_repositories') {
+      await this.#handleInstallationRepositories(payload);
+    } else {
+      logger.warn('Unknown installation event type', { eventType });
+    }
+  }
+
+  async #handleInstallation(payload: any): Promise<void> {
+    const { action, installation, repositories } = payload;
+    const installationId = String(installation.id);
+
+    logger.info('Handling installation event', { action, installationId: installation.id, account: installation.account?.login });
+
+    switch (action) {
+      case 'created': {
+        const repos: InstallationRepo[] = (repositories || []).map(this.#mapRepository);
+
+        const data: Omit<GitHubInstallation, 'id' | 'createdAt' | 'updatedAt'> = {
+          githubInstallationId: installation.id,
+          appId: installation.app_id,
+          accountLogin: installation.account.login,
+          accountId: installation.account.id,
+          accountType: installation.account.type === 'Organization' ? 'Organization' : 'User',
+          repositories: repos,
+          permissions: installation.permissions || {},
+          events: installation.events || [],
+          status: 'active',
+        };
+
+        await this.#repo.create(data, installationId);
+        logger.info('Installation created', { installationId, account: installation.account.login, repoCount: repos.length });
+        break;
+      }
+
+      case 'deleted': {
+        const existing = await this.#repo.findById(installationId);
+        if (existing) {
+          await this.#repo.updateStatus(installationId, 'deleted');
+          if (existing.linkedUserId) {
+            await this.#repo.unlinkUser(installationId);
+          }
+          logger.info('Installation deleted', { installationId });
+        }
+        break;
+      }
+
+      case 'suspend': {
+        await this.#updateStatusIfExists(installationId, 'suspended');
+        break;
+      }
+
+      case 'unsuspend': {
+        await this.#updateStatusIfExists(installationId, 'active');
+        break;
+      }
+
+      default:
+        logger.info('Unhandled installation action', { action, installationId });
+    }
+  }
+
+  async #handleInstallationRepositories(payload: any): Promise<void> {
+    const { action, installation, repositories_added, repositories_removed } = payload;
+    const installationId = String(installation.id);
+
+    logger.info('Handling installation_repositories event', { action, installationId: installation.id });
+
+    const existing = await this.#repo.findById(installationId);
+    if (!existing) {
+      logger.warn('Installation not found for repository update', { installationId });
+      return;
+    }
+
+    let updatedRepos = [...existing.repositories];
+
+    if (action === 'added' && repositories_added) {
+      const newRepos: InstallationRepo[] = repositories_added.map(this.#mapRepository);
+      updatedRepos = [...updatedRepos, ...newRepos];
+    }
+
+    if (action === 'removed' && repositories_removed) {
+      const removedIds = new Set(repositories_removed.map((r: any) => r.id));
+      updatedRepos = updatedRepos.filter((r) => !removedIds.has(r.id));
+    }
+
+    await this.#repo.updateRepositories(installationId, updatedRepos);
+    logger.info('Installation repositories updated', { installationId, repoCount: updatedRepos.length });
+  }
+
+  async #updateStatusIfExists(installationId: string, status: GitHubInstallation['status']): Promise<void> {
+    const existing = await this.#repo.findById(installationId);
+    if (existing) {
+      await this.#repo.updateStatus(installationId, status);
+      logger.info(`Installation ${status}`, { installationId });
+    }
+  }
+
+  #mapRepository(repo: any): InstallationRepo {
+    return {
+      id: repo.id,
+      name: repo.name,
+      fullName: repo.full_name,
+      private: repo.private ?? false,
+    };
+  }
+}

--- a/libs/server/integrations/src/lib/webhook/__tests__/webhook-pipeline.spec.ts
+++ b/libs/server/integrations/src/lib/webhook/__tests__/webhook-pipeline.spec.ts
@@ -6,6 +6,13 @@ const mockFindByEventId = jest.fn();
 const mockCreateEvent = jest.fn();
 const mockLookupUserId = jest.fn();
 const mockGenerateGameActionFromWebhook = jest.fn().mockResolvedValue(null);
+const mockInstallationHandle = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../services/installation-event.handler', () => ({
+  InstallationEventHandler: jest.fn().mockImplementation(() => ({
+    handle: mockInstallationHandle,
+  })),
+}));
 
 jest.mock('@codeheroes/common', () => ({
   logger: {
@@ -217,6 +224,76 @@ describe('processWebhook', () => {
       undefined,
       undefined
     );
+  });
+
+  describe('installation events', () => {
+    it('should route installation events to InstallationEventHandler', async () => {
+      mockAdapter.validateWebhook.mockReturnValue({
+        isValid: true,
+        eventType: 'installation',
+        eventId: 'delivery-456',
+      });
+      const body = { action: 'created', installation: { id: 123 } };
+      const req = createMockReq({ body });
+      const res = createMockRes();
+
+      await processWebhook({ req, res, provider: 'github' });
+
+      expect(res._status).toBe(200);
+      expect(res._body).toBe('Installation event processed');
+      expect(mockInstallationHandle).toHaveBeenCalledWith('installation', body);
+    });
+
+    it('should route installation_repositories events to InstallationEventHandler', async () => {
+      mockAdapter.validateWebhook.mockReturnValue({
+        isValid: true,
+        eventType: 'installation_repositories',
+        eventId: 'delivery-789',
+      });
+      const body = { action: 'added', installation: { id: 123 }, repositories_added: [{ id: 1 }] };
+      const req = createMockReq({ body });
+      const res = createMockRes();
+
+      await processWebhook({ req, res, provider: 'github' });
+
+      expect(res._status).toBe(200);
+      expect(res._body).toBe('Installation event processed');
+      expect(mockInstallationHandle).toHaveBeenCalledWith('installation_repositories', body);
+    });
+
+    it('should skip user lookup and game action creation for installation events', async () => {
+      mockAdapter.validateWebhook.mockReturnValue({
+        isValid: true,
+        eventType: 'installation',
+        eventId: 'delivery-456',
+      });
+      const req = createMockReq({ body: { action: 'created', installation: { id: 123 } } });
+      const res = createMockRes();
+
+      await processWebhook({ req, res, provider: 'github' });
+
+      expect(mockStoreRawWebhook).not.toHaveBeenCalled();
+      expect(mockFindByEventId).not.toHaveBeenCalled();
+      expect(mockCreateEvent).not.toHaveBeenCalled();
+      expect(mockLookupUserId).not.toHaveBeenCalled();
+      expect(mockGenerateGameActionFromWebhook).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 when installation handler throws', async () => {
+      mockAdapter.validateWebhook.mockReturnValue({
+        isValid: true,
+        eventType: 'installation',
+        eventId: 'delivery-456',
+      });
+      mockInstallationHandle.mockRejectedValue(new Error('Firestore write failed'));
+      const req = createMockReq({ body: { action: 'created', installation: { id: 123 } } });
+      const res = createMockRes();
+
+      await processWebhook({ req, res, provider: 'github' });
+
+      expect(res._status).toBe(500);
+      expect(res._body).toBe('Internal server error processing webhook');
+    });
   });
 
   it('should treat events with same ID but different providers as separate events', async () => {

--- a/libs/server/integrations/src/lib/webhook/webhook-pipeline.ts
+++ b/libs/server/integrations/src/lib/webhook/webhook-pipeline.ts
@@ -4,6 +4,7 @@ import { CreateEventInput, EventService } from '@codeheroes/event';
 import { ConnectedAccountProvider } from '@codeheroes/types';
 import { ProviderFactory } from '../providers/provider.factory';
 import { GameActionService } from '../services/game-action.service';
+import { InstallationEventHandler } from '../services/installation-event.handler';
 import { WebhookEvent, WebhookProcessResult } from './webhook-event.types';
 
 export interface WebhookPipelineParams {
@@ -45,6 +46,14 @@ export async function processWebhook({ req, res, provider, secret }: WebhookPipe
     const eventId = validation.eventId;
 
     logger.log('Processing event:', `${provider}.${eventType}${req.body?.action ? `.${req.body.action}` : ''}`);
+
+    // Step 2.5: Handle GitHub App installation lifecycle events
+    if (eventType === 'installation' || eventType === 'installation_repositories') {
+      const handler = new InstallationEventHandler();
+      await handler.handle(eventType, req.body);
+      res.status(200).send('Installation event processed');
+      return;
+    }
 
     // Step 3: Extract user ID using provider adapter
     const externalUserId = providerAdapter.extractUserId(req.body);

--- a/libs/server/progression-engine/src/lib/config/special-badges.config.ts
+++ b/libs/server/progression-engine/src/lib/config/special-badges.config.ts
@@ -48,6 +48,24 @@ export const SPECIAL_BADGES: Record<string, BadgeDefinition> = {
     category: 'special',
     metadata: { trigger: 'installation_setup' },
   },
+  fleet_commander: {
+    id: 'fleet_commander',
+    name: 'Fleet Commander',
+    description: 'Tracking 5 or more repositories via the Code Heroes GitHub App',
+    icon: '🚀',
+    rarity: BadgeRarity.UNCOMMON,
+    category: 'special',
+    metadata: { trigger: 'installation_repos', threshold: 5 },
+  },
+  mission_control: {
+    id: 'mission_control',
+    name: 'Mission Control',
+    description: 'Tracking 10 or more repositories via the Code Heroes GitHub App',
+    icon: '🛰️',
+    rarity: BadgeRarity.RARE,
+    category: 'special',
+    metadata: { trigger: 'installation_repos', threshold: 10 },
+  },
 
   // ═══════════════════════════════════════════════════════════════════
   // STREAK BADGES (Future)

--- a/libs/server/progression-engine/src/lib/config/special-badges.config.ts
+++ b/libs/server/progression-engine/src/lib/config/special-badges.config.ts
@@ -37,6 +37,19 @@ export const SPECIAL_BADGES: Record<string, BadgeDefinition> = {
   },
 
   // ═══════════════════════════════════════════════════════════════════
+  // ONBOARDING BADGES
+  // ═══════════════════════════════════════════════════════════════════
+  connected: {
+    id: 'connected',
+    name: 'Connected',
+    description: 'Linked your first repository via the Code Heroes GitHub App',
+    icon: '🔗',
+    rarity: BadgeRarity.COMMON,
+    category: 'special',
+    metadata: { trigger: 'installation_setup' },
+  },
+
+  // ═══════════════════════════════════════════════════════════════════
   // STREAK BADGES (Future)
   // ═══════════════════════════════════════════════════════════════════
   // streak_master: {

--- a/libs/types/src/lib/collections/collections.ts
+++ b/libs/types/src/lib/collections/collections.ts
@@ -7,6 +7,7 @@ export enum Collections {
   Badges = 'badges',
   ConnectedAccounts = 'connectedAccounts',
   GameActions = 'gameActions',
+  Installations = 'installations',
   Notifications = 'notifications',
   Projects = 'projects',
   RepoProjectMap = 'repoProjectMap',

--- a/libs/types/src/lib/index.ts
+++ b/libs/types/src/lib/index.ts
@@ -30,6 +30,8 @@ export * from './game/metrics.types';
 // export * from './api/responses.types';
 // export * from './api/dto.types';
 
+export * from './installation/installation.types';
+
 export * from './unmatched-event/unmatched-event.types';
 
 export * from './notifications/notification.types';

--- a/libs/types/src/lib/installation/installation.types.ts
+++ b/libs/types/src/lib/installation/installation.types.ts
@@ -1,0 +1,40 @@
+export interface GitHubInstallation {
+  id: string;
+  githubInstallationId: number;
+  appId: number;
+  accountLogin: string;
+  accountId: number;
+  accountType: 'User' | 'Organization';
+  repositories: InstallationRepository[];
+  permissions: Record<string, string>;
+  events: string[];
+  status: 'active' | 'suspended' | 'deleted';
+  linkedUserId?: string;
+  linkedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface InstallationRepository {
+  id: number;
+  name: string;
+  fullName: string;
+  private: boolean;
+}
+
+export interface InstallationSetupDto {
+  installationId: number;
+  setupAction: 'install' | 'update' | 'request';
+}
+
+export interface InstallationSummaryDto {
+  id: string;
+  accountLogin: string;
+  accountType: 'User' | 'Organization';
+  repositoryCount: number;
+  repositories: InstallationRepository[];
+  status: 'active' | 'suspended' | 'deleted';
+  linkedUserId?: string;
+  linkedAt?: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

- Users can install the "Code Heroes" GitHub App on their personal account or org to automatically track coding activity
- Self-service flow: install app on GitHub → redirect back to PWA → repos appear
- Dual-mode webhook verification supports both legacy manual webhooks and new GitHub App webhooks during migration
- New `/repositories` page in PWA for managing connected repos
- Admin endpoint for cross-user installation overview

## Changes

### Types & Data Model
- `GitHubInstallation`, `InstallationRepository`, `InstallationSummaryDto` types
- `Installations` added to `Collections` enum
- Firestore security rules (server-only access)

### Backend
- `InstallationRepository` — Firestore CRUD for installations
- `GitHubAppService` — JWT generation, installation token creation, GitHub API calls
- `InstallationEventHandler` — handles `installation` and `installation_repositories` webhook events
- Dual-secret webhook verification in `github-receiver` (detects app webhooks via `installation` payload field)
- `InstallationsController` — REST endpoints: setup, list, detail, unlink, admin overview

### Frontend (PWA)
- `/repositories` page with empty state (install CTA), setup flow (query param handling), and installation list
- `InstallationsService` for API communication
- Settings page "My Repositories" link
- `githubAppSlug` environment config

## Test plan

- [ ] Deploy backend to test environment (`codeheroes-test`)
- [ ] Deploy app to test environment
- [ ] Configure `GITHUB_APP_WEBHOOK_SECRET` and `GITHUB_APP_PRIVATE_KEY` secrets
- [ ] Install "Code Heroes Test" GitHub App on `mschilling/codeheroes-support`
- [ ] Verify installation webhook creates Firestore document
- [ ] Open `test.codeheroes.app/repositories` and verify redirect flow
- [ ] Push a commit to test repo, verify event processing works
- [ ] Verify existing manual webhooks still work (dual-mode)