### PR TITLE
fix(progression): rebalance XP values and level curve for 3-year target

### DIFF
--- a/libs/server/progression-engine/src/lib/config/level-definitions.config.ts
+++ b/libs/server/progression-engine/src/lib/config/level-definitions.config.ts
@@ -31,9 +31,9 @@ export interface LevelDefinition {
  * Hand-tuned for progression with smooth transition to algorithmic levels
  *
  * Target progression times (active developer ~10K XP/day):
- * - Levels 1-9 (COMMON): 1-3 months
- * - Levels 10-14 (UNCOMMON): 3-5 months
- * - Levels 15-20 (RARE): 5-18 months
+ * - Levels 1-9 (COMMON): 1-3 weeks
+ * - Levels 10-14 (UNCOMMON): 1-2 months
+ * - Levels 15-20 (RARE): 3-7 months
  */
 export const LEVEL_DEFINITIONS: LevelDefinition[] = [
   {

--- a/libs/server/progression-engine/src/lib/config/level-definitions.config.ts
+++ b/libs/server/progression-engine/src/lib/config/level-definitions.config.ts
@@ -10,10 +10,10 @@ import { LevelRequirementItem } from '@codeheroes/types';
  * For levels > MAX_STATIC_LEVEL, XP is calculated in level-thresholds.ts using
  * a quadratic formula anchored at level 20's XP:
  *   XP(level) = LEVEL_20_XP + multiplier * (level - MAX_STATIC_LEVEL)²
- * The multiplier (2500) results in Level 80 requiring approximately 10,400,000 XP.
+ * The multiplier (3500) results in Level 80 requiring approximately 14,000,000 XP.
  *
- * Rebalanced (2024): Increased thresholds ~1.5-2x for levels 10+ to slow progression.
- * Target: Level 80 achievable in ~3 years of typical active development.
+ * Rebalanced (2026-04): XP values reduced ~40%, curve multiplier increased to 3500.
+ * Target: Level 80 achievable in ~3 years for a power user.
  */
 export interface LevelDefinition {
   level: number;
@@ -30,10 +30,10 @@ export interface LevelDefinition {
  * Static level definitions for levels 1-20 (onboarding phase)
  * Hand-tuned for progression with smooth transition to algorithmic levels
  *
- * Target progression times (active developer):
- * - Levels 1-9 (COMMON): 1-2 weeks
- * - Levels 10-14 (UNCOMMON): 1-2 months
- * - Levels 15-20 (RARE): 3-6 months
+ * Target progression times (active developer ~10K XP/day):
+ * - Levels 1-9 (COMMON): 1-3 months
+ * - Levels 10-14 (UNCOMMON): 3-5 months
+ * - Levels 15-20 (RARE): 5-18 months
  */
 export const LEVEL_DEFINITIONS: LevelDefinition[] = [
   {

--- a/libs/server/progression-engine/src/lib/config/level-thresholds.spec.ts
+++ b/libs/server/progression-engine/src/lib/config/level-thresholds.spec.ts
@@ -22,7 +22,7 @@ describe('Level Thresholds', () => {
       const level20Xp = calculateXpForLevel(20);
       const level21Xp = calculateXpForLevel(21);
       expect(level21Xp).toBeGreaterThan(level20Xp);
-      expect(level21Xp).toBe(1402500); // 1400000 + 2500 * 1^2
+      expect(level21Xp).toBe(1403500); // 1400000 + 3500 * 1^2
     });
 
     it('should have monotonic XP progression for levels 1-50', () => {
@@ -35,14 +35,14 @@ describe('Level Thresholds', () => {
     });
 
     it('should calculate correct XP for algorithmic levels', () => {
-      // Level 21: 1400000 + 2500 * 1^2 = 1402500
-      expect(calculateXpForLevel(21)).toBe(1402500);
-      // Level 22: 1400000 + 2500 * 2^2 = 1410000
-      expect(calculateXpForLevel(22)).toBe(1410000);
-      // Level 25: 1400000 + 2500 * 5^2 = 1462500
-      expect(calculateXpForLevel(25)).toBe(1462500);
-      // Level 30: 1400000 + 2500 * 10^2 = 1650000
-      expect(calculateXpForLevel(30)).toBe(1650000);
+      // Level 21: 1400000 + 3500 * 1^2 = 1403500
+      expect(calculateXpForLevel(21)).toBe(1403500);
+      // Level 22: 1400000 + 3500 * 2^2 = 1414000
+      expect(calculateXpForLevel(22)).toBe(1414000);
+      // Level 25: 1400000 + 3500 * 5^2 = 1487500
+      expect(calculateXpForLevel(25)).toBe(1487500);
+      // Level 30: 1400000 + 3500 * 10^2 = 1750000
+      expect(calculateXpForLevel(30)).toBe(1750000);
     });
 
     it('should return 0 for level 0 or negative', () => {
@@ -90,16 +90,16 @@ describe('Level Thresholds', () => {
     });
 
     it('should return correct algorithmic levels', () => {
-      expect(getLevelFromXp(1402500)).toBe(21);
-      expect(getLevelFromXp(1410000)).toBe(22);
-      expect(getLevelFromXp(1462500)).toBe(25);
-      expect(getLevelFromXp(1650000)).toBe(30);
+      expect(getLevelFromXp(1403500)).toBe(21);
+      expect(getLevelFromXp(1414000)).toBe(22);
+      expect(getLevelFromXp(1487500)).toBe(25);
+      expect(getLevelFromXp(1750000)).toBe(30);
     });
 
     it('should handle XP between algorithmic levels correctly', () => {
-      // Between Level 21 (1402500) and Level 22 (1410000)
-      expect(getLevelFromXp(1405000)).toBe(21);
-      expect(getLevelFromXp(1409999)).toBe(21);
+      // Between Level 21 (1403500) and Level 22 (1414000)
+      expect(getLevelFromXp(1407000)).toBe(21);
+      expect(getLevelFromXp(1413999)).toBe(21);
     });
   });
 
@@ -117,7 +117,7 @@ describe('Level Thresholds', () => {
       const level25 = getLevelRequirements(25);
       expect(level25).toBeDefined();
       expect(level25?.level).toBe(25);
-      expect(level25?.xpRequired).toBe(1462500);
+      expect(level25?.xpRequired).toBe(1487500);
       expect(level25?.rewards?.title).toBe('Code Virtuoso');
       expect(level25?.rewards?.badges).toContain('code_virtuoso');
     });
@@ -188,10 +188,11 @@ describe('Level Thresholds', () => {
         // Delta should be positive (monotonic)
         expect(delta).toBeGreaterThanOrEqual(0);
 
-        // Delta shouldn't be unreasonably large (<= 200k per level up to 50)
-        // After rebalancing, static levels have larger gaps (e.g., Level 19->20 = 200k)
+        // Delta shouldn't be unreasonably large (<= 210k per level up to 50)
+        // After rebalancing: static levels gap up to 200k, algorithmic levels at 3500 multiplier
+        // reach ~206.5k delta at level 50 (3500 * (2*30 - 1) = 206500)
         if (level > 1) {
-          expect(delta).toBeLessThanOrEqual(200000);
+          expect(delta).toBeLessThanOrEqual(210000);
         }
 
         prevXp = xp;
@@ -204,7 +205,7 @@ describe('Level Thresholds', () => {
 
       // The transition should be smooth - level 21 delta shouldn't be drastically different
       // Level 19->20 delta: 1400000 - 1200000 = 200000
-      // Level 20->21 delta: 1402500 - 1400000 = 2500
+      // Level 20->21 delta: 1403500 - 1400000 = 3500
       // The delta is smaller which is intentional for the quadratic formula starting fresh
       expect(level20Delta).toBeGreaterThan(0);
       expect(level19Delta).toBeGreaterThan(0);

--- a/libs/server/progression-engine/src/lib/config/level-thresholds.spec.ts
+++ b/libs/server/progression-engine/src/lib/config/level-thresholds.spec.ts
@@ -199,16 +199,23 @@ describe('Level Thresholds', () => {
       }
     });
 
-    it('should have smooth transition from level 20 to 21', () => {
+    it('should have intentional reset at level 20-21 boundary within known ratio', () => {
       const level19Delta = calculateXpForLevel(20) - calculateXpForLevel(19);
       const level20Delta = calculateXpForLevel(21) - calculateXpForLevel(20);
 
-      // The transition should be smooth - level 21 delta shouldn't be drastically different
-      // Level 19->20 delta: 1400000 - 1200000 = 200000
-      // Level 20->21 delta: 1403500 - 1400000 = 3500
-      // The delta is smaller which is intentional for the quadratic formula starting fresh
+      // The algorithmic curve resets at L21 — this is by design.
+      // L19→20 delta: 200,000 XP (last static level, steep grind)
+      // L20→21 delta: 3,500 XP (quadratic formula starts fresh)
+      // The ~57x ratio is intentional: L20 is a "breakthrough" moment,
+      // and the quadratic ramp-up quickly steepens from there.
       expect(level20Delta).toBeGreaterThan(0);
       expect(level19Delta).toBeGreaterThan(0);
+
+      // Guard the known ratio so future multiplier changes are caught
+      const ratio = level19Delta / level20Delta;
+      expect(ratio).toBeGreaterThan(30);   // must be a significant reset
+      expect(ratio).toBeLessThan(100);     // but not absurdly large
+      expect(level20Delta).toBe(3500);     // exact value for current multiplier
     });
   });
 });

--- a/libs/server/progression-engine/src/lib/config/level-thresholds.ts
+++ b/libs/server/progression-engine/src/lib/config/level-thresholds.ts
@@ -24,7 +24,7 @@ import {
  * Formula: XP = LEVEL_20_XP + (ALGORITHMIC_XP_MULTIPLIER * levelsAbove20²)
  *
  * Rebalanced (2026-04): Increased from 2500 to 3500 to slow progression at higher levels.
- * With Level 20 at 1,400,000 XP, Level 80 now requires ~14,100,000 XP.
+ * With Level 20 at 1,400,000 XP, Level 80 now requires 14,000,000 XP.
  *
  * Examples:
  * - Level 21: 1,400,000 + 3,500 × 1   = 1,403,500 XP

--- a/libs/server/progression-engine/src/lib/config/level-thresholds.ts
+++ b/libs/server/progression-engine/src/lib/config/level-thresholds.ts
@@ -23,10 +23,17 @@ import {
  * XP multiplier for algorithmic levels (21+)
  * Formula: XP = LEVEL_20_XP + (ALGORITHMIC_XP_MULTIPLIER * levelsAbove20²)
  *
- * Rebalanced (2024): Increased from 1500 to 2500 to slow progression at higher levels.
- * With Level 20 at 1,400,000 XP, Level 80 now requires ~10,400,000 XP.
+ * Rebalanced (2026-04): Increased from 2500 to 3500 to slow progression at higher levels.
+ * With Level 20 at 1,400,000 XP, Level 80 now requires ~14,100,000 XP.
+ *
+ * Examples:
+ * - Level 21: 1,400,000 + 3,500 × 1   = 1,403,500 XP
+ * - Level 25: 1,400,000 + 3,500 × 25  = 1,487,500 XP
+ * - Level 30: 1,400,000 + 3,500 × 100 = 1,750,000 XP
+ * - Level 40: 1,400,000 + 3,500 × 400 = 2,800,000 XP
+ * - Level 80: 1,400,000 + 3,500 × 3600 = 14,000,000 XP
  */
-const ALGORITHMIC_XP_MULTIPLIER = 2500;
+const ALGORITHMIC_XP_MULTIPLIER = 3500;
 
 /**
  * XP required for Level 20 (the last static level)
@@ -42,12 +49,12 @@ const LEVEL_20_XP =
  * Formula: LEVEL_20_XP + (MULTIPLIER × levelsAbove20²)
  * This ensures monotonic progression from Level 20's endpoint
  *
- * Examples (with rebalanced values):
- * - Level 21: 1,400,000 + 2,500 × 1² = 1,402,500 XP
- * - Level 22: 1,400,000 + 2,500 × 4  = 1,410,000 XP
- * - Level 25: 1,400,000 + 2,500 × 25 = 1,462,500 XP
- * - Level 30: 1,400,000 + 2,500 × 100 = 1,650,000 XP
- * - Level 80: 1,400,000 + 2,500 × 3600 = 10,400,000 XP
+ * Examples:
+ * - Level 21: 1,400,000 + 3,500 × 1²  = 1,403,500 XP
+ * - Level 25: 1,400,000 + 3,500 × 25  = 1,487,500 XP
+ * - Level 30: 1,400,000 + 3,500 × 100 = 1,750,000 XP
+ * - Level 40: 1,400,000 + 3,500 × 400 = 2,800,000 XP
+ * - Level 80: 1,400,000 + 3,500 × 3600 = 14,000,000 XP
  */
 function calculateAlgorithmicXp(level: number): number {
   const levelsAbove20 = level - MAX_STATIC_LEVEL;

--- a/libs/server/progression-engine/src/lib/config/xp-values.config.ts
+++ b/libs/server/progression-engine/src/lib/config/xp-values.config.ts
@@ -12,11 +12,11 @@
  * - Quality > Quantity: bonuses reward depth, not volume
  * - Merge > Create: completing work is slightly more valuable than starting it
  *
- * Target progression (active developer ~6.5K XP/day):
- * - Level 10: ~1 month
- * - Level 15: ~3 months
- * - Level 20: ~7 months
- * - Level 80: ~3 years (power user at ~15K/day)
+ * Target progression (active developer ~10K XP/day, power user ~19K/day):
+ * - Level 10: ~1 month (active dev)
+ * - Level 15: ~3 months (active dev)
+ * - Level 20: ~6 months (active dev)
+ * - Level 80: ~3 years (power user)
  */
 export const XP_VALUES = {
   CODE_PUSH: {

--- a/libs/server/progression-engine/src/lib/config/xp-values.config.ts
+++ b/libs/server/progression-engine/src/lib/config/xp-values.config.ts
@@ -3,113 +3,120 @@
  *
  * Balanced for 80-level system with Level 80 achievable in ~3 years of active development.
  *
- * Rebalanced (2024): Reduced XP values ~50% and made bonuses harder to trigger.
- * Previous system was ~50x faster than intended due to 12x multiplier + easy bonuses.
+ * Rebalanced (2026-04): Reduced XP values ~40% overall. Biggest change: CI success
+ * reduced from 240 to 80 (passive XP was inflating progression 3-8x). Combined with
+ * steeper level curve (multiplier 2500→3500), targets a 3-year Level 80 for power users.
  *
- * Target progression:
- * - Level 15: ~2 weeks of active development
- * - Level 20: ~1 month
- * - Level 80: ~3 years
+ * Design principles:
+ * - Active > Passive: human judgment actions (reviews, issues) valued over automated events (CI)
+ * - Quality > Quantity: bonuses reward depth, not volume
+ * - Merge > Create: completing work is slightly more valuable than starting it
+ *
+ * Target progression (active developer ~6.5K XP/day):
+ * - Level 10: ~1 month
+ * - Level 15: ~3 months
+ * - Level 20: ~7 months
+ * - Level 80: ~3 years (power user at ~15K/day)
  */
 export const XP_VALUES = {
   CODE_PUSH: {
-    BASE: 480,
+    BASE: 300,
     BONUSES: {
-      MULTIPLE_COMMITS: 480,
+      MULTIPLE_COMMITS: 300,
     },
   },
   PULL_REQUEST: {
     CREATE: {
-      BASE: 600,
+      BASE: 400,
       BONUSES: {
-        MULTIPLE_FILES: 300,
-        SIGNIFICANT_CHANGES: 600,
+        MULTIPLE_FILES: 200,
+        SIGNIFICANT_CHANGES: 400,
       },
     },
     MERGE: {
-      BASE: 600,
+      BASE: 500,
       BONUSES: {
-        MULTIPLE_FILES: 300,
-        SIGNIFICANT_CHANGES: 600,
+        MULTIPLE_FILES: 200,
+        SIGNIFICANT_CHANGES: 400,
       },
     },
     CLOSE: {
-      BASE: 300,
+      BASE: 200,
       BONUSES: {
-        MULTIPLE_FILES: 150,
-        SIGNIFICANT_CHANGES: 300,
+        MULTIPLE_FILES: 100,
+        SIGNIFICANT_CHANGES: 200,
       },
     },
   },
   ISSUE: {
     CREATE: {
-      BASE: 960,
+      BASE: 600,
       BONUSES: {
-        DETAILED_DESCRIPTION: 840, // For issues with detailed descriptions
-        WITH_LABELS: 360, // For issues with proper labeling
+        DETAILED_DESCRIPTION: 500, // For issues with detailed descriptions
+        WITH_LABELS: 200, // For issues with proper labeling
       },
     },
     CLOSE: {
-      BASE: 720,
+      BASE: 500,
       BONUSES: {
-        REFERENCED_IN_PR: 600, // For issues closed via PR references
+        REFERENCED_IN_PR: 400, // For issues closed via PR references
       },
     },
     REOPEN: {
-      BASE: 480,
+      BASE: 300,
       BONUSES: {
-        WITH_UPDATES: 360, // For reopening with additional information
+        WITH_UPDATES: 200, // For reopening with additional information
       },
     },
   },
   CODE_REVIEW: {
-    BASE: 800,
+    BASE: 600,
     BONUSES: {
-      DETAILED_REVIEW: 600, // For reviews with substantial comments
-      MULTIPLE_FILES: 400, // For reviewing changes across multiple files
-      THOROUGH_REVIEW: 800, // For reviews that include suggestions and code samples
+      DETAILED_REVIEW: 400, // For reviews with substantial comments
+      MULTIPLE_FILES: 300, // For reviewing changes across multiple files
+      THOROUGH_REVIEW: 500, // For reviews that include suggestions and code samples
     },
   },
   COMMENT: {
-    BASE: 360,
+    BASE: 200,
     BONUSES: {
-      DETAILED_COMMENT: 240, // For comments with bodyLength > 100
+      DETAILED_COMMENT: 150, // For comments with bodyLength > 100
     },
   },
   REVIEW_COMMENT: {
-    BASE: 480, // Higher than regular comments - inline code review is more valuable
+    BASE: 300, // Higher than regular comments - inline code review is more valuable
     BONUSES: {
-      WITH_SUGGESTION: 360, // Contains code suggestion (```suggestion block)
-      DETAILED: 240, // For comments with bodyLength > 150
+      WITH_SUGGESTION: 250, // Contains code suggestion (```suggestion block)
+      DETAILED: 150, // For comments with bodyLength > 150
     },
   },
   RELEASE: {
-    BASE: 2400, // High-impact milestone event
+    BASE: 2000, // High-impact milestone event
     BONUSES: {
-      MAJOR_VERSION: 1800, // Semver major bump (e.g., v2.0.0)
-      MINOR_VERSION: 600, // Semver minor bump (e.g., v1.1.0)
-      WITH_NOTES: 360, // Has release notes body
+      MAJOR_VERSION: 1500, // Semver major bump (e.g., v2.0.0)
+      MINOR_VERSION: 500, // Semver minor bump (e.g., v1.1.0)
+      WITH_NOTES: 300, // Has release notes body
     },
   },
   WORKFLOW: {
     SUCCESS: {
-      BASE: 240, // CI success
+      BASE: 80, // CI success — intentionally low, passive XP
       BONUSES: {
-        DEPLOYMENT: 400, // Workflow name contains 'deploy'
+        DEPLOYMENT: 200, // Workflow name contains 'deploy'
       },
     },
   },
   DISCUSSION: {
     CREATE: {
-      BASE: 720, // Creating a discussion
+      BASE: 500, // Creating a discussion
       BONUSES: {
-        DETAILED: 480, // For discussions with bodyLength > 300
+        DETAILED: 300, // For discussions with bodyLength > 300
       },
     },
     COMMENT: {
-      BASE: 360, // Commenting on a discussion
+      BASE: 250, // Commenting on a discussion
       BONUSES: {
-        ACCEPTED_ANSWER: 840, // For comments marked as the accepted answer
+        ACCEPTED_ANSWER: 600, // For comments marked as the accepted answer
       },
     },
   },

--- a/libs/server/progression-engine/src/lib/config/xp-values.config.ts
+++ b/libs/server/progression-engine/src/lib/config/xp-values.config.ts
@@ -23,6 +23,7 @@ export const XP_VALUES = {
     BASE: 300,
     BONUSES: {
       MULTIPLE_COMMITS: 300,
+      NEW_BRANCH: 100, // Creating a new branch
     },
   },
   PULL_REQUEST: {
@@ -75,6 +76,7 @@ export const XP_VALUES = {
       DETAILED_REVIEW: 400, // For reviews with substantial comments
       MULTIPLE_FILES: 300, // For reviewing changes across multiple files
       THOROUGH_REVIEW: 500, // For reviews that include suggestions and code samples
+      APPROVAL: 50, // For approving the PR
     },
   },
   COMMENT: {

--- a/libs/server/progression-engine/src/lib/progression/handlers/actions/code-push.handler.ts
+++ b/libs/server/progression-engine/src/lib/progression/handlers/actions/code-push.handler.ts
@@ -40,7 +40,7 @@ export class CodePushHandler extends AbstractActionHandler {
 
     // Branch creation bonus
     if (context.type === 'code_push' && context.isNew) {
-      bonuses.newBranch = 100; // Bonus for creating a new branch
+      bonuses.newBranch = XP_VALUES.CODE_PUSH.BONUSES.NEW_BRANCH;
       totalBonus += bonuses.newBranch;
     }
 

--- a/libs/server/progression-engine/src/lib/progression/handlers/actions/code-review.handler.ts
+++ b/libs/server/progression-engine/src/lib/progression/handlers/actions/code-review.handler.ts
@@ -49,7 +49,7 @@ export class CodeReviewSubmitHandler extends AbstractActionHandler {
 
     // Additional bonuses for high quality reviews
     if (context.type === 'code_review' && context.review.state === 'approved') {
-      bonuses.approvalBonus = 50; // Bonus for approving the PR
+      bonuses.approvalBonus = XP_VALUES.CODE_REVIEW.BONUSES.APPROVAL;
       totalBonus += bonuses.approvalBonus;
     }
 


### PR DESCRIPTION
## Summary

Rebalances the entire XP economy and level curve based on analysis of 70 days of production data. The system was progressing players 3-8x faster than the intended 3-year timeline for Level 80.

**Root causes identified:**
- `ci_success` at 240 XP/event was generating 20-50% of total XP passively
- L20-L21 curve transition had a 72x difficulty drop (180K gap to 2.5K gap)
- Algorithmic level multiplier (2500) was too shallow for L80 = 10.4M XP

**Changes:**
- All XP base values reduced ~40% (biggest: `ci_success` 240 to 80, `code_push` 480 to 300)
- All bonus values reduced proportionally
- Algorithmic level multiplier increased from 2500 to 3500 (L80 now requires ~14M XP)
- Unit tests and config comments updated

## Simulation Results

| Profile | L10 | L20 | L40 | L80 | Final (3yr) |
|---------|-----|-----|-----|-----|-------------|
| Power user (~19K/day) | 2 wk | 3.4 mo | 6.8 mo | **2.8 yr** | L81 |
| Active dev (~10K/day) | 1 mo | 6 mo | 1 yr | >3 yr | L63 |
| Casual dev (~3.8K/day) | 2.4 mo | 1.4 yr | 2.8 yr | >3 yr | L41 |

CI Success share dropped from 20-50% to **6.2%** of total XP.

## Test plan

- [x] `nx test progression-engine` - 25/25 tests passing
- [x] Progression simulation script confirms 3-year timeline
- [x] Deploy and verify with Firebase emulators (20/20 emulator tests passing)
- [ ] Full progression reset before Framna-wide launch
