### PR TITLE
feat: show repository selection mode in installations UI

### DIFF
--- a/apps/api/src/controllers/installations-controller.ts
+++ b/apps/api/src/controllers/installations-controller.ts
@@ -76,6 +76,7 @@ router.post('/setup', validate(setupSchema), async (req, res) => {
           accountLogin: ghInstallation.account.login,
           accountId: ghInstallation.account.id,
           accountType: ghInstallation.account.type === 'Organization' ? 'Organization' : 'User',
+          repositorySelection: ghInstallation.repository_selection === 'all' ? 'all' : 'selected',
           repositories: ghRepos.map((r) => ({
             id: r.id,
             name: r.name,
@@ -250,6 +251,7 @@ function toSummary(installation: GitHubInstallation): InstallationSummaryDto {
     id: installation.id,
     accountLogin: installation.accountLogin,
     accountType: installation.accountType,
+    repositorySelection: installation.repositorySelection ?? 'selected',
     repositoryCount: installation.repositories?.length ?? 0,
     repositories: installation.repositories ?? [],
     status: installation.status,

--- a/apps/api/src/controllers/installations-controller.ts
+++ b/apps/api/src/controllers/installations-controller.ts
@@ -247,13 +247,14 @@ router.delete('/:id', async (req, res) => {
 });
 
 function toSummary(installation: GitHubInstallation): InstallationSummaryDto {
+  const selection = installation.repositorySelection ?? 'selected';
   return {
     id: installation.id,
     accountLogin: installation.accountLogin,
     accountType: installation.accountType,
-    repositorySelection: installation.repositorySelection ?? 'selected',
+    repositorySelection: selection,
     repositoryCount: installation.repositories?.length ?? 0,
-    repositories: installation.repositories ?? [],
+    repositories: selection === 'all' ? [] : (installation.repositories ?? []),
     status: installation.status,
     linkedUserId: installation.linkedUserId,
     linkedAt: installation.linkedAt,

--- a/apps/frontend/app/src/app/pages/repositories/repositories.component.ts
+++ b/apps/frontend/app/src/app/pages/repositories/repositories.component.ts
@@ -76,7 +76,9 @@ import { environment } from '../../../environments/environment';
                 </span>
               </div>
 
-              @if (installation.repositories.length === 0) {
+              @if (installation.repositorySelection === 'all') {
+                <p class="all-repos-text">All repositories enabled</p>
+              } @else if (installation.repositories.length === 0) {
                 <p class="text-sm text-white/40 py-2">No repositories selected</p>
               } @else {
                 <div class="repo-list">
@@ -227,6 +229,13 @@ import { environment } from '../../../environments/environment';
         color: rgb(239, 68, 68);
         background: rgba(239, 68, 68, 0.1);
         border: 1px solid rgba(239, 68, 68, 0.3);
+      }
+
+      .all-repos-text {
+        font-size: 0.875rem;
+        color: var(--neon-cyan, rgb(6, 182, 212));
+        padding: 0.5rem 0;
+        margin: 0;
       }
 
       .repo-list {

--- a/libs/server/integrations/src/lib/services/github-app.service.ts
+++ b/libs/server/integrations/src/lib/services/github-app.service.ts
@@ -100,6 +100,7 @@ export class GitHubAppService {
     id: number;
     app_id: number;
     account: { login: string; id: number; type: string };
+    repository_selection: string;
     permissions: Record<string, string>;
     events: string[];
   }> {

--- a/libs/server/integrations/src/lib/services/github-app.service.ts
+++ b/libs/server/integrations/src/lib/services/github-app.service.ts
@@ -100,7 +100,7 @@ export class GitHubAppService {
     id: number;
     app_id: number;
     account: { login: string; id: number; type: string };
-    repository_selection: string;
+    repository_selection: 'all' | 'selected';
     permissions: Record<string, string>;
     events: string[];
   }> {

--- a/libs/server/integrations/src/lib/services/installation-event.handler.ts
+++ b/libs/server/integrations/src/lib/services/installation-event.handler.ts
@@ -41,6 +41,7 @@ export class InstallationEventHandler {
           accountLogin: installation.account.login,
           accountId: installation.account.id,
           accountType: installation.account.type === 'Organization' ? 'Organization' : 'User',
+          repositorySelection: installation.repository_selection === 'all' ? 'all' : 'selected',
           repositories: repos,
           permissions: installation.permissions || {},
           events: installation.events || [],

--- a/libs/types/src/lib/installation/installation.types.ts
+++ b/libs/types/src/lib/installation/installation.types.ts
@@ -5,6 +5,7 @@ export interface GitHubInstallation {
   accountLogin: string;
   accountId: number;
   accountType: 'User' | 'Organization';
+  repositorySelection: 'all' | 'selected';
   repositories: InstallationRepository[];
   permissions: Record<string, string>;
   events: string[];
@@ -31,6 +32,7 @@ export interface InstallationSummaryDto {
   id: string;
   accountLogin: string;
   accountType: 'User' | 'Organization';
+  repositorySelection: 'all' | 'selected';
   repositoryCount: number;
   repositories: InstallationRepository[];
   status: 'active' | 'suspended' | 'deleted';

--- a/libs/types/src/lib/installation/installation.types.ts
+++ b/libs/types/src/lib/installation/installation.types.ts
@@ -5,7 +5,7 @@ export interface GitHubInstallation {
   accountLogin: string;
   accountId: number;
   accountType: 'User' | 'Organization';
-  repositorySelection: 'all' | 'selected';
+  repositorySelection?: 'all' | 'selected';
   repositories: InstallationRepository[];
   permissions: Record<string, string>;
   events: string[];


### PR DESCRIPTION
## Summary

- Store GitHub App `repository_selection` field (`"all"` or `"selected"`) on installation records
- Show "All repositories enabled" in the PWA when full-access is configured, instead of listing every repo
- Repos are still fetched and stored in Firestore for admin/analytics purposes

## Test plan

- [x] Type checks pass
- [x] Existing webhook pipeline tests pass
- [ ] PWA shows "All repositories enabled" for installations with `repositorySelection: 'all'`
- [x] PWA shows repo list for installations with `repositorySelection: 'selected'`