### PR TITLE
feat: self-service GitHub account linking

### DIFF
--- a/apps/api/src/controllers/users-controller.ts
+++ b/apps/api/src/controllers/users-controller.ts
@@ -119,6 +119,100 @@ router.get('/:userId/connected-accounts', async (req, res) => {
   }
 });
 
+/**
+ * POST /users/:userId/connect-github
+ * Exchange a GitHub OAuth code for user info and create a connected account.
+ */
+router.post('/:userId/connect-github', async (req, res) => {
+  const { userId } = req.params;
+  const { code, redirectUri } = req.body;
+
+  if (!code || !redirectUri) {
+    res.status(400).json({ error: 'Missing code or redirectUri' });
+    return;
+  }
+
+  // Verify the requesting user matches the target userId
+  if (req.user?.customUserId !== userId) {
+    res.status(403).json({ error: 'Access denied' });
+    return;
+  }
+
+  logger.debug('POST /users/:userId/connect-github', { userId });
+
+  try {
+    const clientId = process.env.GITHUB_OAUTH_CLIENT_ID;
+    const clientSecret = process.env.GITHUB_OAUTH_CLIENT_SECRET;
+
+    if (!clientId || !clientSecret) {
+      logger.error('GITHUB_OAUTH_CLIENT_ID or GITHUB_OAUTH_CLIENT_SECRET not configured');
+      res.status(500).json({ error: 'GitHub OAuth not configured' });
+      return;
+    }
+
+    // Exchange code for access token
+    const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
+      method: 'POST',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code, redirect_uri: redirectUri }),
+    });
+
+    const tokenData = await tokenResponse.json();
+    if (tokenData.error || !tokenData.access_token) {
+      logger.error('GitHub OAuth token exchange failed', { error: tokenData.error });
+      res.status(400).json({ error: tokenData.error_description || 'GitHub authorization failed' });
+      return;
+    }
+
+    // Get GitHub user profile
+    const userResponse = await fetch('https://api.github.com/user', {
+      headers: { Authorization: `Bearer ${tokenData.access_token}`, Accept: 'application/vnd.github+json' },
+    });
+
+    if (!userResponse.ok) {
+      res.status(502).json({ error: 'Failed to fetch GitHub user profile' });
+      return;
+    }
+
+    const ghUser = await userResponse.json();
+    const externalUserId = String(ghUser.id);
+    const externalUserName = ghUser.login;
+
+    // Create connected account
+    const db = getFirestore();
+    const docId = `github_${externalUserId}`;
+    const now = getCurrentTimeAsISO();
+
+    const accountRef = db
+      .collection(Collections.Users)
+      .doc(userId)
+      .collection(Collections.ConnectedAccounts)
+      .doc(docId);
+
+    try {
+      await accountRef.create({
+        provider: 'github',
+        externalUserId,
+        externalUserName,
+        createdAt: now,
+        updatedAt: now,
+      });
+    } catch (createError: any) {
+      if (createError?.code === 6 || createError?.code === 'already-exists') {
+        res.json({ message: 'GitHub account already connected', externalUserName });
+        return;
+      }
+      throw createError;
+    }
+
+    logger.info('GitHub account connected', { userId, githubId: externalUserId, githubLogin: externalUserName });
+    res.status(201).json({ message: 'GitHub account connected', externalUserName });
+  } catch (error) {
+    logger.error('Error connecting GitHub account:', error);
+    res.status(500).json({ error: 'Failed to connect GitHub account' });
+  }
+});
+
 router.post('/:userId/connected-accounts', validate(addConnectedAccountSchema), async (req, res) => {
   const { userId } = req.params;
   const { provider, externalUserId, externalUserName } = req.body;

--- a/apps/api/src/controllers/users-controller.ts
+++ b/apps/api/src/controllers/users-controller.ts
@@ -125,10 +125,10 @@ router.get('/:userId/connected-accounts', async (req, res) => {
  */
 router.post('/:userId/connect-github', async (req, res) => {
   const { userId } = req.params;
-  const { code, redirectUri } = req.body;
+  const { code } = req.body;
 
-  if (!code || !redirectUri) {
-    res.status(400).json({ error: 'Missing code or redirectUri' });
+  if (!code) {
+    res.status(400).json({ error: 'Missing code' });
     return;
   }
 
@@ -154,8 +154,14 @@ router.post('/:userId/connect-github', async (req, res) => {
     const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
       method: 'POST',
       headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
-      body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code, redirect_uri: redirectUri }),
+      body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code }),
     });
+
+    if (!tokenResponse.ok) {
+      logger.error('GitHub OAuth token exchange HTTP error', { status: tokenResponse.status });
+      res.status(502).json({ error: 'GitHub authorization failed' });
+      return;
+    }
 
     const tokenData = await tokenResponse.json();
     if (tokenData.error || !tokenData.access_token) {
@@ -178,8 +184,15 @@ router.post('/:userId/connect-github', async (req, res) => {
     const externalUserId = String(ghUser.id);
     const externalUserName = ghUser.login;
 
-    // Create connected account
+    // Verify user exists
     const db = getFirestore();
+    const userDoc = await db.collection(Collections.Users).doc(userId).get();
+    if (!userDoc.exists) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    // Create connected account
     const docId = `github_${externalUserId}`;
     const now = getCurrentTimeAsISO();
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -17,7 +17,7 @@ export const api = onRequest(
   {
     memory: '2GiB',
     timeoutSeconds: 120,
-    secrets: ['GITHUB_APP_ID', 'GITHUB_APP_PRIVATE_KEY'],
+    secrets: ['GITHUB_APP_ID', 'GITHUB_APP_PRIVATE_KEY', 'GITHUB_OAUTH_CLIENT_ID', 'GITHUB_OAUTH_CLIENT_SECRET'],
   },
   defaultApi,
 );

--- a/apps/frontend/app/src/app/pages/settings/settings.component.ts
+++ b/apps/frontend/app/src/app/pages/settings/settings.component.ts
@@ -5,7 +5,6 @@ import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { Auth, GithubAuthProvider, GoogleAuthProvider, signInWithPopup } from '@angular/fire/auth';
 import { Firestore, collection, collectionData } from '@angular/fire/firestore';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { DEFAULT_DAILY_GOAL, ConnectedAccountDto, Collections } from '@codeheroes/types';
 import { UserSettingsService } from '../../core/services/user-settings.service';
 import { UserStatsService } from '../../core/services/user-stats.service';
@@ -589,7 +588,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
   readonly #location = inject(Location);
   readonly #auth = inject(Auth);
   readonly #firestore = inject(Firestore);
-  readonly #http = inject(HttpClient);
   readonly #injector = inject(Injector);
   readonly #settingsService = inject(UserSettingsService);
   readonly #userStatsService = inject(UserStatsService);
@@ -653,6 +651,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
   }
 
   #loadConnectedAccounts(userId: string) {
+    this.#connectedAccountsSub?.unsubscribe();
     const accountsRef = collection(this.#firestore, `users/${userId}/${Collections.ConnectedAccounts}`);
     this.#connectedAccountsSub = runInInjectionContext(this.#injector, () =>
       collectionData(accountsRef, { idField: 'id' }),

--- a/apps/frontend/app/src/app/pages/settings/settings.component.ts
+++ b/apps/frontend/app/src/app/pages/settings/settings.component.ts
@@ -3,7 +3,7 @@ import { DecimalPipe, Location } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
-import { Auth, GithubAuthProvider, GoogleAuthProvider, linkWithPopup, signInWithCredential, signInWithPopup } from '@angular/fire/auth';
+import { Auth, GithubAuthProvider, GoogleAuthProvider, signInWithPopup } from '@angular/fire/auth';
 import { Firestore, collection, collectionData } from '@angular/fire/firestore';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { DEFAULT_DAILY_GOAL, ConnectedAccountDto, Collections } from '@codeheroes/types';
@@ -772,57 +772,27 @@ export class SettingsComponent implements OnInit, OnDestroy {
     this.connectGitHubError.set(null);
 
     try {
+      // Use signInWithPopup to get GitHub identity, then immediately
+      // re-authenticate with Google. We only need the GitHub user ID,
+      // not a persistent Firebase Auth link.
       const provider = new GithubAuthProvider();
-      let githubUid: string | undefined;
-      let githubUsername: string | undefined;
+      const result = await signInWithPopup(this.#auth, provider);
 
-      try {
-        // Try linking directly first
-        const result = await linkWithPopup(this.#auth.currentUser!, provider);
-        const githubProfile = result.user.providerData.find((p) => p.providerId === 'github.com');
-        githubUid = githubProfile?.uid;
-        githubUsername = githubProfile?.displayName || githubProfile?.email || undefined;
-      } catch (linkError: any) {
-        if (linkError?.code === 'auth/email-already-in-use' || linkError?.code === 'auth/credential-already-in-use') {
-          // Email conflict — extract GitHub info from the failed credential
-          const credential = GithubAuthProvider.credentialFromError(linkError);
-          if (credential) {
-            // Sign in with GitHub temporarily to get the profile, then sign back in with Google
-            const githubResult = await signInWithCredential(this.#auth, credential);
-            const githubProfile = githubResult.user.providerData.find((p) => p.providerId === 'github.com');
-            githubUid = githubProfile?.uid;
-            githubUsername = githubProfile?.displayName || githubProfile?.email || undefined;
-
-            // Sign back in as the original Google user
-            // The auth state listener will handle this
-            await signInWithPopup(this.#auth, new GoogleAuthProvider());
-          }
-
-          if (!githubUid) {
-            // Fallback: extract from the error's customData
-            const additionalInfo = linkError?.customData;
-            if (additionalInfo?.email) {
-              this.connectGitHubError.set(
-                'Email conflict: your GitHub email is associated with another account. Please use a different GitHub account or contact support.',
-              );
-              this.isConnectingGitHub.set(false);
-              return;
-            }
-            throw linkError;
-          }
-        } else {
-          throw linkError;
-        }
-      }
+      const githubProfile = result.user.providerData.find((p) => p.providerId === 'github.com');
+      const githubUid = githubProfile?.uid;
+      const githubUsername = githubProfile?.displayName || githubProfile?.email || undefined;
 
       if (!githubUid) {
         throw new Error('Could not retrieve GitHub profile');
       }
 
+      // Re-authenticate with Google to restore the original session
+      await signInWithPopup(this.#auth, new GoogleAuthProvider());
+
       // Create connected account via API
       const token = await this.#auth.currentUser!.getIdToken();
 
-      await fetch(`${environment.apiUrl}/users/${this.#userId}/connected-accounts`, {
+      const response = await fetch(`${environment.apiUrl}/users/${this.#userId}/connected-accounts`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -832,6 +802,10 @@ export class SettingsComponent implements OnInit, OnDestroy {
         }),
       });
 
+      if (!response.ok && response.status !== 409) {
+        throw new Error(`API error: ${response.status}`);
+      }
+
       // Refresh connected accounts list
       this.#loadConnectedAccounts(this.#userId);
       this.isConnectingGitHub.set(false);
@@ -839,10 +813,10 @@ export class SettingsComponent implements OnInit, OnDestroy {
       this.isConnectingGitHub.set(false);
 
       const code = error?.code;
-      if (code === 'auth/provider-already-linked') {
-        this.connectGitHubError.set('GitHub is already connected.');
-      } else if (code === 'auth/popup-closed-by-user') {
+      if (code === 'auth/popup-closed-by-user') {
         // User closed popup — no error needed
+      } else if (code === 'auth/account-exists-with-different-credential') {
+        this.connectGitHubError.set('This GitHub email is linked to another login method. Please use a different GitHub account.');
       } else {
         this.connectGitHubError.set('Failed to connect GitHub. Please try again.');
         console.error('GitHub linking error:', error);

--- a/apps/frontend/app/src/app/pages/settings/settings.component.ts
+++ b/apps/frontend/app/src/app/pages/settings/settings.component.ts
@@ -3,7 +3,7 @@ import { DecimalPipe, Location } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
-import { Auth, GithubAuthProvider, linkWithPopup } from '@angular/fire/auth';
+import { Auth, GithubAuthProvider, GoogleAuthProvider, linkWithPopup, signInWithCredential, signInWithPopup } from '@angular/fire/auth';
 import { Firestore, collection, collectionData } from '@angular/fire/firestore';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { DEFAULT_DAILY_GOAL, ConnectedAccountDto, Collections } from '@codeheroes/types';
@@ -773,24 +773,62 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
     try {
       const provider = new GithubAuthProvider();
-      const result = await linkWithPopup(this.#auth.currentUser!, provider);
+      let githubUid: string | undefined;
+      let githubUsername: string | undefined;
 
-      const githubProfile = result.user.providerData.find((p) => p.providerId === 'github.com');
-      if (!githubProfile?.uid) {
+      try {
+        // Try linking directly first
+        const result = await linkWithPopup(this.#auth.currentUser!, provider);
+        const githubProfile = result.user.providerData.find((p) => p.providerId === 'github.com');
+        githubUid = githubProfile?.uid;
+        githubUsername = githubProfile?.displayName || githubProfile?.email || undefined;
+      } catch (linkError: any) {
+        if (linkError?.code === 'auth/email-already-in-use' || linkError?.code === 'auth/credential-already-in-use') {
+          // Email conflict — extract GitHub info from the failed credential
+          const credential = GithubAuthProvider.credentialFromError(linkError);
+          if (credential) {
+            // Sign in with GitHub temporarily to get the profile, then sign back in with Google
+            const githubResult = await signInWithCredential(this.#auth, credential);
+            const githubProfile = githubResult.user.providerData.find((p) => p.providerId === 'github.com');
+            githubUid = githubProfile?.uid;
+            githubUsername = githubProfile?.displayName || githubProfile?.email || undefined;
+
+            // Sign back in as the original Google user
+            // The auth state listener will handle this
+            await signInWithPopup(this.#auth, new GoogleAuthProvider());
+          }
+
+          if (!githubUid) {
+            // Fallback: extract from the error's customData
+            const additionalInfo = linkError?.customData;
+            if (additionalInfo?.email) {
+              this.connectGitHubError.set(
+                'Email conflict: your GitHub email is associated with another account. Please use a different GitHub account or contact support.',
+              );
+              this.isConnectingGitHub.set(false);
+              return;
+            }
+            throw linkError;
+          }
+        } else {
+          throw linkError;
+        }
+      }
+
+      if (!githubUid) {
         throw new Error('Could not retrieve GitHub profile');
       }
 
       // Create connected account via API
       const token = await this.#auth.currentUser!.getIdToken();
-      const headers = new HttpHeaders().set('Authorization', `Bearer ${token}`);
 
       await fetch(`${environment.apiUrl}/users/${this.#userId}/connected-accounts`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({
           provider: 'github',
-          externalUserId: githubProfile.uid,
-          externalUserName: githubProfile.displayName || githubProfile.email,
+          externalUserId: githubUid,
+          externalUserName: githubUsername,
         }),
       });
 
@@ -801,9 +839,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
       this.isConnectingGitHub.set(false);
 
       const code = error?.code;
-      if (code === 'auth/credential-already-in-use') {
-        this.connectGitHubError.set('This GitHub account is already linked to another user.');
-      } else if (code === 'auth/provider-already-linked') {
+      if (code === 'auth/provider-already-linked') {
         this.connectGitHubError.set('GitHub is already connected.');
       } else if (code === 'auth/popup-closed-by-user') {
         // User closed popup — no error needed

--- a/apps/frontend/app/src/app/pages/settings/settings.component.ts
+++ b/apps/frontend/app/src/app/pages/settings/settings.component.ts
@@ -631,6 +631,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
         this.#userId = userDoc.id;
         this.#loadSettings(userDoc.id);
         this.#loadConnectedAccounts(userDoc.id);
+        this.#completePendingGitHubLink();
 
         // Set account info
         this.userEmail.set(userDoc.email);
@@ -770,12 +771,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
     this.isConnectingGitHub.set(true);
     this.connectGitHubError.set(null);
 
-    const userId = this.#userId;
-
     try {
-      // Get GitHub identity via OAuth popup. We extract the GitHub access token
-      // from the credential result and use it to call the GitHub API directly.
-      // This avoids Firebase Auth session switching issues.
+      // Step 1: GitHub OAuth popup to get access token
       const provider = new GithubAuthProvider();
       const result = await signInWithPopup(this.#auth, provider);
       const credential = GithubAuthProvider.credentialFromResult(result);
@@ -785,7 +782,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
         throw new Error('Could not retrieve GitHub access token');
       }
 
-      // Use the GitHub API to get the authenticated user's profile
+      // Step 2: Get GitHub user profile via API (before auth state changes)
       const ghResponse = await fetch('https://api.github.com/user', {
         headers: { Authorization: `Bearer ${githubAccessToken}`, Accept: 'application/vnd.github+json' },
       });
@@ -795,32 +792,16 @@ export class SettingsComponent implements OnInit, OnDestroy {
       }
 
       const ghUser = await ghResponse.json();
-      const githubUid = String(ghUser.id);
-      const githubUsername = ghUser.login;
 
-      // Re-authenticate with Google to restore the original session
+      // Step 3: Store GitHub info for after Google re-login
+      localStorage.setItem('pendingGitHubLink', JSON.stringify({
+        userId: this.#userId,
+        externalUserId: String(ghUser.id),
+        externalUserName: ghUser.login,
+      }));
+
+      // Step 4: Re-authenticate with Google (this will reload the component)
       await signInWithPopup(this.#auth, new GoogleAuthProvider());
-
-      // Create connected account via API
-      const token = await this.#auth.currentUser!.getIdToken();
-
-      const response = await fetch(`${environment.apiUrl}/users/${userId}/connected-accounts`, {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          provider: 'github',
-          externalUserId: githubUid,
-          externalUserName: githubUsername,
-        }),
-      });
-
-      if (!response.ok && response.status !== 409) {
-        throw new Error(`API error: ${response.status}`);
-      }
-
-      // Refresh connected accounts list
-      this.#loadConnectedAccounts(userId);
-      this.isConnectingGitHub.set(false);
     } catch (error: any) {
       this.isConnectingGitHub.set(false);
 
@@ -834,6 +815,41 @@ export class SettingsComponent implements OnInit, OnDestroy {
       } else {
         this.connectGitHubError.set(`Failed to connect GitHub: ${code || error?.message || 'Unknown error'}`);
       }
+    }
+  }
+
+  /**
+   * Complete a pending GitHub link after Google re-login.
+   * Called from ngOnInit when localStorage contains pending data.
+   */
+  async #completePendingGitHubLink() {
+    const pending = localStorage.getItem('pendingGitHubLink');
+    if (!pending) return;
+
+    localStorage.removeItem('pendingGitHubLink');
+
+    try {
+      const { userId, externalUserId, externalUserName } = JSON.parse(pending);
+      const token = await this.#auth.currentUser?.getIdToken();
+      if (!token) return;
+
+      const response = await fetch(`${environment.apiUrl}/users/${userId}/connected-accounts`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'github',
+          externalUserId,
+          externalUserName,
+        }),
+      });
+
+      if (response.ok || response.status === 409) {
+        this.#loadConnectedAccounts(userId);
+      } else {
+        console.error('Failed to create connected account:', response.status);
+      }
+    } catch (error) {
+      console.error('Failed to complete GitHub link:', error);
     }
   }
 

--- a/apps/frontend/app/src/app/pages/settings/settings.component.ts
+++ b/apps/frontend/app/src/app/pages/settings/settings.component.ts
@@ -3,7 +3,7 @@ import { DecimalPipe, Location } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
-import { Auth, GithubAuthProvider, GoogleAuthProvider, signInWithPopup } from '@angular/fire/auth';
+import { Auth } from '@angular/fire/auth';
 import { Firestore, collection, collectionData } from '@angular/fire/firestore';
 import { DEFAULT_DAILY_GOAL, ConnectedAccountDto, Collections } from '@codeheroes/types';
 import { UserSettingsService } from '../../core/services/user-settings.service';
@@ -765,91 +765,77 @@ export class SettingsComponent implements OnInit, OnDestroy {
     return this.connectedAccounts().some((a) => a.provider === 'github');
   }
 
-  async connectGitHub() {
-    if (!this.#userId || this.isConnectingGitHub()) return;
+  connectGitHub() {
+    if (!this.#userId) return;
 
-    this.isConnectingGitHub.set(true);
-    this.connectGitHubError.set(null);
-
-    try {
-      // Step 1: GitHub OAuth popup to get access token
-      const provider = new GithubAuthProvider();
-      const result = await signInWithPopup(this.#auth, provider);
-      const credential = GithubAuthProvider.credentialFromResult(result);
-      const githubAccessToken = credential?.accessToken;
-
-      if (!githubAccessToken) {
-        throw new Error('Could not retrieve GitHub access token');
-      }
-
-      // Step 2: Get GitHub user profile via API (before auth state changes)
-      const ghResponse = await fetch('https://api.github.com/user', {
-        headers: { Authorization: `Bearer ${githubAccessToken}`, Accept: 'application/vnd.github+json' },
-      });
-
-      if (!ghResponse.ok) {
-        throw new Error(`GitHub API error: ${ghResponse.status}`);
-      }
-
-      const ghUser = await ghResponse.json();
-
-      // Step 3: Store GitHub info for after Google re-login
-      localStorage.setItem('pendingGitHubLink', JSON.stringify({
-        userId: this.#userId,
-        externalUserId: String(ghUser.id),
-        externalUserName: ghUser.login,
-      }));
-
-      // Step 4: Re-authenticate with Google (this will reload the component)
-      await signInWithPopup(this.#auth, new GoogleAuthProvider());
-    } catch (error: any) {
-      this.isConnectingGitHub.set(false);
-
-      console.error('GitHub linking error:', error?.code, error?.message, error);
-
-      const code = error?.code;
-      if (code === 'auth/popup-closed-by-user' || code === 'auth/cancelled-popup-request') {
-        // User closed popup — no error needed
-      } else if (code === 'auth/account-exists-with-different-credential') {
-        this.connectGitHubError.set('This GitHub email is linked to another login method. Please use a different GitHub account.');
-      } else {
-        this.connectGitHubError.set(`Failed to connect GitHub: ${code || error?.message || 'Unknown error'}`);
-      }
+    // Direct GitHub OAuth flow — no Firebase Auth involvement.
+    // Redirect to GitHub, which redirects back to /settings with a code param.
+    // We exchange the code for user info server-side or client-side.
+    const clientId = environment.githubOAuthClientId;
+    if (!clientId) {
+      this.connectGitHubError.set('GitHub OAuth not configured.');
+      return;
     }
+
+    // Store userId for after redirect
+    localStorage.setItem('pendingGitHubLink', this.#userId);
+
+    const redirectUri = `${window.location.origin}/settings`;
+    const state = crypto.randomUUID();
+    localStorage.setItem('githubOAuthState', state);
+
+    window.location.href =
+      `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&state=${state}&scope=read:user`;
   }
 
   /**
-   * Complete a pending GitHub link after Google re-login.
-   * Called from ngOnInit when localStorage contains pending data.
+   * Complete GitHub OAuth flow after redirect back from GitHub.
+   * GitHub redirects to /settings?code=XXX&state=YYY
    */
   async #completePendingGitHubLink() {
-    const pending = localStorage.getItem('pendingGitHubLink');
-    if (!pending) return;
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const state = params.get('state');
 
+    if (!code || !state) return;
+
+    const savedState = localStorage.getItem('githubOAuthState');
+    const userId = localStorage.getItem('pendingGitHubLink');
+    localStorage.removeItem('githubOAuthState');
     localStorage.removeItem('pendingGitHubLink');
 
-    try {
-      const { userId, externalUserId, externalUserName } = JSON.parse(pending);
-      const token = await this.#auth.currentUser?.getIdToken();
-      if (!token) return;
+    // Clear query params from URL
+    window.history.replaceState({}, '', window.location.pathname);
 
-      const response = await fetch(`${environment.apiUrl}/users/${userId}/connected-accounts`, {
+    if (state !== savedState || !userId) {
+      this.connectGitHubError.set('GitHub authentication failed. Please try again.');
+      return;
+    }
+
+    this.isConnectingGitHub.set(true);
+
+    try {
+      const token = await this.#auth.currentUser?.getIdToken();
+      if (!token) throw new Error('Not authenticated');
+
+      // Exchange code for GitHub user info via our API
+      const response = await fetch(`${environment.apiUrl}/users/${userId}/connect-github`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          provider: 'github',
-          externalUserId,
-          externalUserName,
-        }),
+        body: JSON.stringify({ code, redirectUri: `${window.location.origin}/settings` }),
       });
 
-      if (response.ok || response.status === 409) {
-        this.#loadConnectedAccounts(userId);
-      } else {
-        console.error('Failed to create connected account:', response.status);
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || `Failed: ${response.status}`);
       }
-    } catch (error) {
-      console.error('Failed to complete GitHub link:', error);
+
+      this.#loadConnectedAccounts(userId);
+      this.isConnectingGitHub.set(false);
+    } catch (error: any) {
+      this.isConnectingGitHub.set(false);
+      this.connectGitHubError.set(`Failed to connect GitHub: ${error?.message || 'Unknown error'}`);
+      console.error('GitHub OAuth error:', error);
     }
   }
 

--- a/apps/frontend/app/src/app/pages/settings/settings.component.ts
+++ b/apps/frontend/app/src/app/pages/settings/settings.component.ts
@@ -812,14 +812,15 @@ export class SettingsComponent implements OnInit, OnDestroy {
     } catch (error: any) {
       this.isConnectingGitHub.set(false);
 
+      console.error('GitHub linking error:', error?.code, error?.message, error);
+
       const code = error?.code;
-      if (code === 'auth/popup-closed-by-user') {
+      if (code === 'auth/popup-closed-by-user' || code === 'auth/cancelled-popup-request') {
         // User closed popup — no error needed
       } else if (code === 'auth/account-exists-with-different-credential') {
         this.connectGitHubError.set('This GitHub email is linked to another login method. Please use a different GitHub account.');
       } else {
-        this.connectGitHubError.set('Failed to connect GitHub. Please try again.');
-        console.error('GitHub linking error:', error);
+        this.connectGitHubError.set(`Failed to connect GitHub: ${code || error?.message || 'Unknown error'}`);
       }
     }
   }

--- a/apps/frontend/app/src/app/pages/settings/settings.component.ts
+++ b/apps/frontend/app/src/app/pages/settings/settings.component.ts
@@ -3,7 +3,9 @@ import { DecimalPipe, Location } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
+import { Auth, GithubAuthProvider, linkWithPopup } from '@angular/fire/auth';
 import { Firestore, collection, collectionData } from '@angular/fire/firestore';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { DEFAULT_DAILY_GOAL, ConnectedAccountDto, Collections } from '@codeheroes/types';
 import { UserSettingsService } from '../../core/services/user-settings.service';
 import { UserStatsService } from '../../core/services/user-stats.service';
@@ -126,6 +128,23 @@ const GOAL_PRESETS = [4000, 8000, 12000, 16000];
             <h2 class="section-title">Connected Accounts</h2>
             <p class="section-description">Accounts linked to your profile</p>
             <app-connected-accounts [accounts]="connectedAccounts()" [showTitle]="false" />
+
+            @if (!hasGitHubAccount()) {
+              <button
+                type="button"
+                class="connect-github-button"
+                [disabled]="isConnectingGitHub()"
+                (click)="connectGitHub()"
+              >
+                <svg class="connect-github-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
+                </svg>
+                {{ isConnectingGitHub() ? 'Connecting...' : 'Connect GitHub' }}
+              </button>
+            }
+            @if (connectGitHubError()) {
+              <p class="save-error">{{ connectGitHubError() }}</p>
+            }
           </section>
 
           <!-- Repositories Section -->
@@ -320,6 +339,38 @@ const GOAL_PRESETS = [4000, 8000, 12000, 16000];
       .save-button:disabled {
         opacity: 0.4;
         cursor: not-allowed;
+      }
+
+      .connect-github-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-top: 0.75rem;
+        padding: 0.625rem 1.25rem;
+        border-radius: 8px;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        background: rgba(255, 255, 255, 0.05);
+        color: rgba(255, 255, 255, 0.9);
+        font-size: 0.875rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+
+      .connect-github-button:hover:not(:disabled) {
+        border-color: var(--neon-cyan);
+        background: rgba(6, 182, 212, 0.1);
+        color: var(--neon-cyan);
+      }
+
+      .connect-github-button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .connect-github-icon {
+        width: 18px;
+        height: 18px;
       }
 
       .save-success {
@@ -536,7 +587,9 @@ const GOAL_PRESETS = [4000, 8000, 12000, 16000];
 })
 export class SettingsComponent implements OnInit, OnDestroy {
   readonly #location = inject(Location);
+  readonly #auth = inject(Auth);
   readonly #firestore = inject(Firestore);
+  readonly #http = inject(HttpClient);
   readonly #injector = inject(Injector);
   readonly #settingsService = inject(UserSettingsService);
   readonly #userStatsService = inject(UserStatsService);
@@ -557,6 +610,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
   notificationSaveError = signal(false);
 
   connectedAccounts = signal<ConnectedAccountDto[]>([]);
+  isConnectingGitHub = signal(false);
+  connectGitHubError = signal<string | null>(null);
   userEmail = signal<string | null>(null);
   memberSince = signal<string | null>(null);
 
@@ -704,6 +759,59 @@ export class SettingsComponent implements OnInit, OnDestroy {
         this.#errorTimeout = setTimeout(() => this.notificationSaveError.set(false), 5000);
       },
     });
+  }
+
+  hasGitHubAccount(): boolean {
+    return this.connectedAccounts().some((a) => a.provider === 'github');
+  }
+
+  async connectGitHub() {
+    if (!this.#userId || this.isConnectingGitHub()) return;
+
+    this.isConnectingGitHub.set(true);
+    this.connectGitHubError.set(null);
+
+    try {
+      const provider = new GithubAuthProvider();
+      const result = await linkWithPopup(this.#auth.currentUser!, provider);
+
+      const githubProfile = result.user.providerData.find((p) => p.providerId === 'github.com');
+      if (!githubProfile?.uid) {
+        throw new Error('Could not retrieve GitHub profile');
+      }
+
+      // Create connected account via API
+      const token = await this.#auth.currentUser!.getIdToken();
+      const headers = new HttpHeaders().set('Authorization', `Bearer ${token}`);
+
+      await fetch(`${environment.apiUrl}/users/${this.#userId}/connected-accounts`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'github',
+          externalUserId: githubProfile.uid,
+          externalUserName: githubProfile.displayName || githubProfile.email,
+        }),
+      });
+
+      // Refresh connected accounts list
+      this.#loadConnectedAccounts(this.#userId);
+      this.isConnectingGitHub.set(false);
+    } catch (error: any) {
+      this.isConnectingGitHub.set(false);
+
+      const code = error?.code;
+      if (code === 'auth/credential-already-in-use') {
+        this.connectGitHubError.set('This GitHub account is already linked to another user.');
+      } else if (code === 'auth/provider-already-linked') {
+        this.connectGitHubError.set('GitHub is already connected.');
+      } else if (code === 'auth/popup-closed-by-user') {
+        // User closed popup — no error needed
+      } else {
+        this.connectGitHubError.set('Failed to connect GitHub. Please try again.');
+        console.error('GitHub linking error:', error);
+      }
+    }
   }
 
   goBack() {

--- a/apps/frontend/app/src/app/pages/settings/settings.component.ts
+++ b/apps/frontend/app/src/app/pages/settings/settings.component.ts
@@ -771,6 +771,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
     // Direct GitHub OAuth flow — no Firebase Auth involvement.
     // Redirect to GitHub, which redirects back to /settings with a code param.
     // We exchange the code for user info server-side or client-side.
+    this.connectGitHubError.set(null);
+
     const clientId = environment.githubOAuthClientId;
     if (!clientId) {
       this.connectGitHubError.set('GitHub OAuth not configured.');
@@ -822,7 +824,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
       const response = await fetch(`${environment.apiUrl}/users/${userId}/connect-github`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code, redirectUri: `${window.location.origin}/settings` }),
+        body: JSON.stringify({ code }),
       });
 
       if (!response.ok) {

--- a/apps/frontend/app/src/app/pages/settings/settings.component.ts
+++ b/apps/frontend/app/src/app/pages/settings/settings.component.ts
@@ -770,20 +770,33 @@ export class SettingsComponent implements OnInit, OnDestroy {
     this.isConnectingGitHub.set(true);
     this.connectGitHubError.set(null);
 
+    const userId = this.#userId;
+
     try {
-      // Use signInWithPopup to get GitHub identity, then immediately
-      // re-authenticate with Google. We only need the GitHub user ID,
-      // not a persistent Firebase Auth link.
+      // Get GitHub identity via OAuth popup. We extract the GitHub access token
+      // from the credential result and use it to call the GitHub API directly.
+      // This avoids Firebase Auth session switching issues.
       const provider = new GithubAuthProvider();
       const result = await signInWithPopup(this.#auth, provider);
+      const credential = GithubAuthProvider.credentialFromResult(result);
+      const githubAccessToken = credential?.accessToken;
 
-      const githubProfile = result.user.providerData.find((p) => p.providerId === 'github.com');
-      const githubUid = githubProfile?.uid;
-      const githubUsername = githubProfile?.displayName || githubProfile?.email || undefined;
-
-      if (!githubUid) {
-        throw new Error('Could not retrieve GitHub profile');
+      if (!githubAccessToken) {
+        throw new Error('Could not retrieve GitHub access token');
       }
+
+      // Use the GitHub API to get the authenticated user's profile
+      const ghResponse = await fetch('https://api.github.com/user', {
+        headers: { Authorization: `Bearer ${githubAccessToken}`, Accept: 'application/vnd.github+json' },
+      });
+
+      if (!ghResponse.ok) {
+        throw new Error(`GitHub API error: ${ghResponse.status}`);
+      }
+
+      const ghUser = await ghResponse.json();
+      const githubUid = String(ghUser.id);
+      const githubUsername = ghUser.login;
 
       // Re-authenticate with Google to restore the original session
       await signInWithPopup(this.#auth, new GoogleAuthProvider());
@@ -791,7 +804,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
       // Create connected account via API
       const token = await this.#auth.currentUser!.getIdToken();
 
-      const response = await fetch(`${environment.apiUrl}/users/${this.#userId}/connected-accounts`, {
+      const response = await fetch(`${environment.apiUrl}/users/${userId}/connected-accounts`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -806,7 +819,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
       }
 
       // Refresh connected accounts list
-      this.#loadConnectedAccounts(this.#userId);
+      this.#loadConnectedAccounts(userId);
       this.isConnectingGitHub.set(false);
     } catch (error: any) {
       this.isConnectingGitHub.set(false);

--- a/apps/frontend/app/src/environments/environment.interface.ts
+++ b/apps/frontend/app/src/environments/environment.interface.ts
@@ -17,6 +17,7 @@ export interface Environment {
   appVersion: string;
   vapidKey?: string;
   githubAppSlug: string;
+  githubOAuthClientId?: string;
   autoLogin?: {
     email: string;
     password: string;

--- a/apps/frontend/app/src/environments/environment.local.ts.template
+++ b/apps/frontend/app/src/environments/environment.local.ts.template
@@ -14,5 +14,6 @@ export const environment: Environment = {
   },
   appVersion: '${APP_VERSION}',
   githubAppSlug: 'code-heroes-test',
+  githubOAuthClientId: 'Ov23lizRLHjVRvqSoCLV',
   vapidKey: '${FIREBASE_VAPID_KEY}',
 };

--- a/apps/frontend/app/src/environments/environment.prod.ts.template
+++ b/apps/frontend/app/src/environments/environment.prod.ts.template
@@ -14,6 +14,7 @@ export const environment: Environment = {
     measurementId: '${FIREBASE_PROD_MEASUREMENT_ID}',
   },
   appVersion: '${APP_VERSION}',
-  githubAppSlug: 'code-heroes',
+  githubAppSlug: 'code-heroes-app',
+  githubOAuthClientId: '${GITHUB_OAUTH_CLIENT_ID}',
   vapidKey: '${FIREBASE_PROD_VAPID_KEY}',
 };

--- a/apps/frontend/app/src/environments/environment.test.ts.template
+++ b/apps/frontend/app/src/environments/environment.test.ts.template
@@ -15,5 +15,6 @@ export const environment: Environment = {
   },
   appVersion: '${APP_VERSION}',
   githubAppSlug: 'code-heroes-test',
+  githubOAuthClientId: 'Ov23lizRLHjVRvqSoCLV',
   vapidKey: '${FIREBASE_TEST_VAPID_KEY}',
 };

--- a/apps/frontend/app/src/environments/environment.ts
+++ b/apps/frontend/app/src/environments/environment.ts
@@ -14,5 +14,6 @@ export const environment: Environment = {
   },
   appVersion: 'dev',
   githubAppSlug: 'code-heroes-test',
+  githubOAuthClientId: 'Ov23lizRLHjVRvqSoCLV',
   vapidKey: '',
 };

--- a/scripts/setup-firebase.js
+++ b/scripts/setup-firebase.js
@@ -64,6 +64,7 @@ const appProdConfig = appProdTemplate
   .replace('${FIREBASE_PROD_APP_ID}', process.env.FIREBASE_PROD_APP_ID || process.env.FIREBASE_APP_ID)
   .replace('${FIREBASE_PROD_MEASUREMENT_ID}', process.env.FIREBASE_PROD_MEASUREMENT_ID || process.env.FIREBASE_MEASUREMENT_ID || '')
   .replace('${FIREBASE_PROD_VAPID_KEY}', process.env.FIREBASE_PROD_VAPID_KEY || process.env.FIREBASE_VAPID_KEY || '')
+  .replace('${GITHUB_OAUTH_CLIENT_ID}', process.env.GITHUB_OAUTH_CLIENT_ID || '')
   .replace('${APP_VERSION}', appVersion);
 fs.writeFileSync('apps/frontend/app/src/environments/environment.prod.ts', appProdConfig);
 


### PR DESCRIPTION
## Summary

- Add "Connect GitHub" button in Settings → Connected Accounts section
- Uses direct GitHub OAuth redirect flow (not Firebase Auth linking) to avoid email conflict issues
- Backend endpoint `POST /users/:userId/connect-github` exchanges OAuth code for GitHub user profile and creates connectedAccount
- Frontend stores pending link data in localStorage to survive the OAuth redirect cycle

## Architecture

Firebase Auth's `linkWithPopup` and `signInWithPopup` both fail when the GitHub email differs from the Google login email (`auth/account-exists-with-different-credential`). Instead, we use a direct GitHub OAuth flow:

1. Frontend redirects to `github.com/login/oauth/authorize`
2. GitHub redirects back to `/settings?code=XXX&state=YYY`
3. Frontend sends code to backend `POST /users/:userId/connect-github`
4. Backend exchanges code for access token → fetches GitHub user profile → creates connectedAccount doc

No Firebase Auth session switching, no popups, no email conflicts.

## Onboarding flow (complete)

1. Login with Google (@framna.com) → user doc auto-created
2. **Connect GitHub (this PR)** → connectedAccount created (1 click + authorize)
3. Install GitHub App (#452) → repos tracked (1 click)
4. Push code → XP + badges

## Test plan

- [x] GitHub OAuth App configured (callback URL: `https://test.codeheroes.app/settings`)
- [x] GitHub provider enabled in Firebase Console (test project)
- [x] "Connect GitHub" button appears when no GitHub account is linked
- [x] Clicking button redirects to GitHub OAuth authorize page
- [x] After authorization, redirects back and connected account is created in Firestore
- [x] Button disappears after successful connection
- [ ] Push to tracked repo → event matched to user (not unmatched)