### PR TITLE
feat: guided onboarding flow for GitHub connect + app install

### DIFF
--- a/apps/api/src/controllers/users-controller.ts
+++ b/apps/api/src/controllers/users-controller.ts
@@ -312,6 +312,7 @@ router.delete('/:userId/connected-accounts/:accountId', async (req, res) => {
 const updateSettingsSchema = z.object({
   dailyGoal: z.number().int().min(1000).max(100000).optional(),
   notificationsEnabled: z.boolean().optional(),
+  onboardingDismissed: z.boolean().optional(),
 });
 
 router.get('/:userId/settings', async (req, res) => {

--- a/apps/frontend/app/src/app/app.routes.ts
+++ b/apps/frontend/app/src/app/app.routes.ts
@@ -35,6 +35,12 @@ export const appRoutes: Routes = [
     loadComponent: loadWithReload(() => import('./pages/hq/hq.component').then((m) => m.HqComponent)),
   },
   {
+    path: 'onboarding',
+    loadComponent: loadWithReload(() =>
+      import('./pages/onboarding/onboarding.component').then((m) => m.OnboardingComponent),
+    ),
+  },
+  {
     path: 'leaderboard/heroes',
     loadComponent: loadWithReload(() =>
       import('./pages/leaderboard/full-leaderboard.component').then((m) => m.FullLeaderboardComponent),

--- a/apps/frontend/app/src/app/core/services/onboarding.service.ts
+++ b/apps/frontend/app/src/app/core/services/onboarding.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable, Injector, runInInjectionContext } from '@angular/core';
 import { Auth, user } from '@angular/fire/auth';
 import { Firestore, collection, collectionData } from '@angular/fire/firestore';
-import { Observable, combineLatest, from, map, of, switchMap, catchError, shareReplay } from 'rxjs';
+import { Observable, combineLatest, map, of, switchMap, catchError, shareReplay } from 'rxjs';
 import { Collections, ConnectedAccountDto } from '@codeheroes/types';
 import { InstallationsService } from './installations.service';
 import { UserSettingsService } from './user-settings.service';
@@ -83,7 +83,6 @@ export class OnboardingService {
 
     const state = crypto.randomUUID();
     localStorage.setItem('githubOAuthState', state);
-    localStorage.setItem('githubOAuthReturn', returnPath);
 
     const redirectUri = `${window.location.origin}${returnPath}`;
     window.location.href =

--- a/apps/frontend/app/src/app/core/services/onboarding.service.ts
+++ b/apps/frontend/app/src/app/core/services/onboarding.service.ts
@@ -1,0 +1,96 @@
+import { inject, Injectable, Injector, runInInjectionContext } from '@angular/core';
+import { Auth, user } from '@angular/fire/auth';
+import { Firestore, collection, collectionData } from '@angular/fire/firestore';
+import { Observable, combineLatest, from, map, of, switchMap, catchError, shareReplay } from 'rxjs';
+import { Collections, ConnectedAccountDto } from '@codeheroes/types';
+import { InstallationsService } from './installations.service';
+import { UserSettingsService } from './user-settings.service';
+import { UserStatsService } from './user-stats.service';
+import { environment } from '../../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class OnboardingService {
+  readonly #auth = inject(Auth);
+  readonly #firestore = inject(Firestore);
+  readonly #injector = inject(Injector);
+  readonly #installationsService = inject(InstallationsService);
+  readonly #settingsService = inject(UserSettingsService);
+  readonly #userStatsService = inject(UserStatsService);
+  readonly #authUser$ = user(this.#auth);
+
+  readonly #userDoc$ = this.#userStatsService.getCurrentUserDoc().pipe(shareReplay(1));
+
+  readonly hasGitHubAccount$: Observable<boolean> = this.#userDoc$.pipe(
+    switchMap((userDoc) => {
+      if (!userDoc) return of(false);
+      const accountsRef = collection(this.#firestore, `users/${userDoc.id}/${Collections.ConnectedAccounts}`);
+      return runInInjectionContext(this.#injector, () =>
+        collectionData(accountsRef, { idField: 'id' }),
+      ).pipe(
+        map((accounts) => (accounts as ConnectedAccountDto[]).some((a) => a.provider === 'github')),
+        catchError(() => of(false)),
+      );
+    }),
+    shareReplay(1),
+  );
+
+  readonly hasInstallations$: Observable<boolean> = this.#authUser$.pipe(
+    switchMap((authUser) => {
+      if (!authUser) return of(false);
+      return this.#installationsService.getInstallations().pipe(
+        map((installations) => installations.length > 0),
+        catchError(() => of(false)),
+      );
+    }),
+    shareReplay(1),
+  );
+
+  readonly isOnboardingComplete$: Observable<boolean> = combineLatest([
+    this.hasGitHubAccount$,
+    this.hasInstallations$,
+  ]).pipe(
+    map(([hasGitHub, hasInstallations]) => hasGitHub && hasInstallations),
+    shareReplay(1),
+  );
+
+  readonly shouldShowOnboarding$: Observable<boolean> = this.#userDoc$.pipe(
+    switchMap((userDoc) => {
+      if (!userDoc) return of(false);
+      return combineLatest([
+        this.isOnboardingComplete$,
+        this.#settingsService.getSettings(userDoc.id).pipe(
+          map((s) => s.onboardingDismissed === true),
+          catchError(() => of(false)),
+        ),
+      ]).pipe(
+        map(([complete, dismissed]) => !complete && !dismissed),
+      );
+    }),
+    shareReplay(1),
+  );
+
+  getUserId$(): Observable<string | null> {
+    return this.#userDoc$.pipe(map((doc) => doc?.id ?? null));
+  }
+
+  dismissOnboarding(userId: string): Observable<any> {
+    return this.#settingsService.updateSettings(userId, { onboardingDismissed: true });
+  }
+
+  connectGitHub(returnPath: string = '/onboarding') {
+    const clientId = environment.githubOAuthClientId;
+    if (!clientId) return;
+
+    const state = crypto.randomUUID();
+    localStorage.setItem('githubOAuthState', state);
+    localStorage.setItem('githubOAuthReturn', returnPath);
+
+    const redirectUri = `${window.location.origin}${returnPath}`;
+    window.location.href =
+      `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&state=${state}&scope=read:user`;
+  }
+
+  getGitHubAppInstallUrl(): string {
+    return `https://github.com/apps/${environment.githubAppSlug}/installations/new`;
+  }
+}

--- a/apps/frontend/app/src/app/pages/hq/hq.component.ts
+++ b/apps/frontend/app/src/app/pages/hq/hq.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject, signal, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
-import { Subscription, switchMap } from 'rxjs';
+import { Subscription, switchMap, take } from 'rxjs';
+import { OnboardingService } from '../../core/services/onboarding.service';
 import { UserSettingsService } from '../../core/services/user-settings.service';
 import { NotificationDataService } from '../../core/services/notification-data.service';
 import {
@@ -119,6 +120,7 @@ export class HqComponent implements OnInit, OnDestroy {
   readonly #hqDataService = inject(HqDataService);
   readonly #userSettingsService = inject(UserSettingsService);
   readonly #notificationService = inject(NotificationDataService);
+  readonly #onboardingService = inject(OnboardingService);
   readonly #router = inject(Router);
 
   #dailyProgressSub: Subscription | null = null;
@@ -136,6 +138,14 @@ export class HqComponent implements OnInit, OnDestroy {
   highlights = signal<Highlight[]>([]);
 
   ngOnInit() {
+    // Check if onboarding should be shown (one-time check)
+    this.#onboardingService.shouldShowOnboarding$.pipe(take(1)).subscribe((shouldShow) => {
+      if (shouldShow) {
+        this.#router.navigate(['/onboarding']);
+        return;
+      }
+    });
+
     this.#notificationSub = this.#notificationService.unreadCount$.subscribe((count) =>
       this.unreadCount.set(count),
     );

--- a/apps/frontend/app/src/app/pages/onboarding/onboarding.component.ts
+++ b/apps/frontend/app/src/app/pages/onboarding/onboarding.component.ts
@@ -55,6 +55,7 @@ import { environment } from '../../../environments/environment';
             <p class="step-description">
               Your coding activity is now being tracked.
               Push some code to earn your first XP!
+              Redirecting to dashboard...
             </p>
             <button type="button" class="action-button" (click)="goToDashboard()">
               Go to Dashboard
@@ -330,6 +331,7 @@ export class OnboardingComponent implements OnInit, OnDestroy {
 
   #subs: Subscription[] = [];
   #userId: string | null = null;
+  #redirectTimeout: ReturnType<typeof setTimeout> | null = null;
 
   ngOnInit() {
     // Load onboarding state
@@ -339,7 +341,10 @@ export class OnboardingComponent implements OnInit, OnDestroy {
         this.githubConnected.set(v);
         this.isLoading.set(false);
       }),
-      this.#onboardingService.hasInstallations$.subscribe((v) => this.appInstalled.set(v)),
+      this.#onboardingService.hasInstallations$.subscribe((v) => {
+        this.appInstalled.set(v);
+        this.#checkAutoRedirect();
+      }),
     );
 
     // Handle GitHub OAuth callback
@@ -351,6 +356,7 @@ export class OnboardingComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.#subs.forEach((s) => s.unsubscribe());
+    if (this.#redirectTimeout) clearTimeout(this.#redirectTimeout);
   }
 
   connectGitHub() {
@@ -370,6 +376,12 @@ export class OnboardingComponent implements OnInit, OnDestroy {
 
   goBack() {
     this.#location.back();
+  }
+
+  #checkAutoRedirect() {
+    if (this.allComplete() && !this.#redirectTimeout) {
+      this.#redirectTimeout = setTimeout(() => this.#router.navigate(['/hq']), 3000);
+    }
   }
 
   #handleOAuthCallback() {
@@ -416,6 +428,7 @@ export class OnboardingComponent implements OnInit, OnDestroy {
 
         this.githubConnected.set(true);
         this.isProcessing.set(false);
+        this.#checkAutoRedirect();
       } catch (err: any) {
         this.error.set(`Failed to connect GitHub: ${err?.message || 'Unknown error'}`);
         this.isProcessing.set(false);
@@ -430,17 +443,29 @@ export class OnboardingComponent implements OnInit, OnDestroy {
 
     if (!installationId || !setupAction) return;
 
+    const numericId = Number(installationId);
+    if (isNaN(numericId) || numericId <= 0) {
+      this.error.set('Invalid installation ID.');
+      return;
+    }
+
     window.history.replaceState({}, '', window.location.pathname);
     this.isProcessing.set(true);
 
-    this.#installationsService.setupInstallation(Number(installationId), setupAction).subscribe({
+    this.#installationsService.setupInstallation(numericId, setupAction).subscribe({
       next: () => {
         this.appInstalled.set(true);
         this.isProcessing.set(false);
       },
-      error: () => {
-        this.appInstalled.set(true); // Might already exist, treat as success
+      error: (err) => {
         this.isProcessing.set(false);
+        // 409 = already linked, treat as success
+        if (err?.status === 409) {
+          this.appInstalled.set(true);
+        } else {
+          this.error.set('Failed to set up installation. Please try again.');
+          console.error('Installation setup error:', err);
+        }
       },
     });
   }

--- a/apps/frontend/app/src/app/pages/onboarding/onboarding.component.ts
+++ b/apps/frontend/app/src/app/pages/onboarding/onboarding.component.ts
@@ -365,9 +365,13 @@ export class OnboardingComponent implements OnInit, OnDestroy {
 
   skip() {
     if (this.#userId) {
-      this.#onboardingService.dismissOnboarding(this.#userId).subscribe();
+      this.#onboardingService.dismissOnboarding(this.#userId).subscribe({
+        next: () => this.#router.navigate(['/hq']),
+        error: () => this.#router.navigate(['/hq']),
+      });
+    } else {
+      this.#router.navigate(['/hq']);
     }
-    this.#router.navigate(['/hq']);
   }
 
   goToDashboard() {

--- a/apps/frontend/app/src/app/pages/onboarding/onboarding.component.ts
+++ b/apps/frontend/app/src/app/pages/onboarding/onboarding.component.ts
@@ -1,0 +1,447 @@
+import { Component, inject, signal, OnInit, OnDestroy, computed } from '@angular/core';
+import { Router } from '@angular/router';
+import { Location } from '@angular/common';
+import { Auth } from '@angular/fire/auth';
+import { Subscription, take } from 'rxjs';
+import { OnboardingService } from '../../core/services/onboarding.service';
+import { InstallationsService } from '../../core/services/installations.service';
+import { environment } from '../../../environments/environment';
+
+@Component({
+  selector: 'app-onboarding',
+  standalone: true,
+  template: `
+    <div class="onboarding-container">
+      <!-- Header -->
+      <header class="onboarding-header">
+        <button type="button" (click)="goBack()" class="back-button" aria-label="Back">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <h1 class="onboarding-title">Get Started</h1>
+      </header>
+
+      <!-- Step Indicator -->
+      <div class="step-indicator">
+        <div class="step-dot" [class.step-done]="githubConnected()" [class.step-active]="!githubConnected()">
+          @if (githubConnected()) { <span class="step-check">&#10003;</span> } @else { <span>1</span> }
+        </div>
+        <div class="step-line" [class.step-line-done]="githubConnected()"></div>
+        <div class="step-dot" [class.step-done]="appInstalled()" [class.step-active]="githubConnected() && !appInstalled()">
+          @if (appInstalled()) { <span class="step-check">&#10003;</span> } @else { <span>2</span> }
+        </div>
+      </div>
+      <div class="step-labels">
+        <span [class.step-label-active]="!githubConnected()">GitHub</span>
+        <span [class.step-label-active]="githubConnected() && !appInstalled()">Repos</span>
+      </div>
+
+      <!-- Content -->
+      <main class="onboarding-content">
+        @if (isLoading()) {
+          <div class="loading-state">
+            <div class="loading-pulse">Loading...</div>
+          </div>
+        } @else if (isProcessing()) {
+          <div class="loading-state">
+            <div class="loading-pulse">Setting up...</div>
+          </div>
+        } @else if (allComplete()) {
+          <!-- All done! -->
+          <div class="step-card">
+            <div class="completion-icon">&#127881;</div>
+            <h2 class="step-title">You're all set!</h2>
+            <p class="step-description">
+              Your coding activity is now being tracked.
+              Push some code to earn your first XP!
+            </p>
+            <button type="button" class="action-button" (click)="goToDashboard()">
+              Go to Dashboard
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          </div>
+        } @else if (!githubConnected()) {
+          <!-- Step 1: Connect GitHub -->
+          <div class="step-card">
+            <div class="step-icon" [innerHTML]="githubIcon"></div>
+            <h2 class="step-title">Connect GitHub</h2>
+            <p class="step-description">
+              Link your GitHub account so we can track
+              your commits, PRs, and code reviews.
+            </p>
+            @if (error()) {
+              <p class="error-text">{{ error() }}</p>
+            }
+            <button type="button" class="action-button" (click)="connectGitHub()">
+              Connect GitHub
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+              </svg>
+            </button>
+          </div>
+        } @else {
+          <!-- Step 2: Install App -->
+          <div class="step-card">
+            <div class="step-icon" [innerHTML]="repoIcon"></div>
+            <h2 class="step-title">Track your repos</h2>
+            <p class="step-description">
+              Install the Code Heroes app on your GitHub
+              repositories to start earning XP.
+            </p>
+            <a [href]="installUrl" class="action-button" target="_self">
+              Install on GitHub
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+              </svg>
+            </a>
+          </div>
+        }
+      </main>
+
+      <!-- Skip -->
+      @if (!allComplete() && !isLoading() && !isProcessing()) {
+        <button type="button" class="skip-button" (click)="skip()">
+          Skip for now
+        </button>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      :host { display: block; }
+
+      .onboarding-container {
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 1.5rem;
+      }
+
+      .onboarding-header {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        width: 100%;
+        max-width: 480px;
+        margin-bottom: 2rem;
+      }
+
+      .back-button {
+        background: transparent;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 6px;
+        padding: 0.5rem;
+        min-width: 40px;
+        min-height: 40px;
+        color: rgba(255, 255, 255, 0.6);
+        cursor: pointer;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .back-button:hover { color: white; border-color: rgba(255, 255, 255, 0.4); }
+
+      .onboarding-title {
+        font-size: 1.75rem;
+        font-weight: 700;
+        font-style: italic;
+        color: white;
+        margin: 0;
+      }
+
+      .step-indicator {
+        display: flex;
+        align-items: center;
+        gap: 0;
+        margin-bottom: 0.5rem;
+      }
+
+      .step-dot {
+        width: 36px;
+        height: 36px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.875rem;
+        font-weight: 600;
+        border: 2px solid rgba(255, 255, 255, 0.15);
+        color: rgba(255, 255, 255, 0.3);
+        background: transparent;
+        transition: all 0.3s;
+      }
+
+      .step-active {
+        border-color: var(--neon-cyan, rgb(6, 182, 212));
+        color: var(--neon-cyan, rgb(6, 182, 212));
+        background: rgba(6, 182, 212, 0.1);
+        box-shadow: 0 0 12px rgba(6, 182, 212, 0.2);
+      }
+
+      .step-done {
+        border-color: rgb(34, 197, 94);
+        color: rgb(34, 197, 94);
+        background: rgba(34, 197, 94, 0.1);
+      }
+
+      .step-check { font-size: 1rem; }
+
+      .step-line {
+        width: 60px;
+        height: 2px;
+        background: rgba(255, 255, 255, 0.1);
+        transition: background 0.3s;
+      }
+      .step-line-done { background: rgb(34, 197, 94); }
+
+      .step-labels {
+        display: flex;
+        gap: 60px;
+        margin-bottom: 2rem;
+        font-size: 0.75rem;
+        color: rgba(255, 255, 255, 0.3);
+      }
+      .step-label-active { color: var(--neon-cyan, rgb(6, 182, 212)); }
+
+      .onboarding-content {
+        width: 100%;
+        max-width: 480px;
+      }
+
+      .step-card {
+        background: rgba(0, 0, 0, 0.3);
+        border: 1px solid rgba(139, 92, 246, 0.2);
+        border-radius: 20px;
+        padding: 2rem;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .step-icon {
+        width: 48px;
+        height: 48px;
+        color: rgba(255, 255, 255, 0.5);
+      }
+      .step-icon svg { width: 48px; height: 48px; }
+
+      .completion-icon { font-size: 3rem; }
+
+      .step-title {
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: white;
+        margin: 0;
+      }
+
+      .step-description {
+        font-size: 0.9375rem;
+        color: rgba(255, 255, 255, 0.5);
+        line-height: 1.5;
+        margin: 0;
+        max-width: 320px;
+      }
+
+      .error-text {
+        font-size: 0.875rem;
+        color: rgb(239, 68, 68);
+        padding: 0.5rem 1rem;
+        background: rgba(239, 68, 68, 0.1);
+        border: 1px solid rgba(239, 68, 68, 0.3);
+        border-radius: 8px;
+        margin: 0;
+      }
+
+      .action-button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.875rem 1.75rem;
+        border-radius: 12px;
+        border: none;
+        background: linear-gradient(135deg, rgb(6, 182, 212), rgb(139, 92, 246));
+        color: white;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.2s;
+        text-decoration: none;
+        margin-top: 0.5rem;
+      }
+      .action-button:hover { box-shadow: 0 0 28px rgba(6, 182, 212, 0.35); }
+
+      .skip-button {
+        margin-top: 1.5rem;
+        background: none;
+        border: none;
+        color: rgba(255, 255, 255, 0.35);
+        font-size: 0.875rem;
+        cursor: pointer;
+        padding: 0.5rem 1rem;
+        transition: color 0.2s;
+      }
+      .skip-button:hover { color: rgba(255, 255, 255, 0.6); }
+
+      .loading-state {
+        display: flex;
+        justify-content: center;
+        padding: 4rem 0;
+      }
+
+      .loading-pulse {
+        color: rgba(139, 92, 246, 0.7);
+        font-size: 1.125rem;
+        animation: pulse 1.5s ease-in-out infinite;
+      }
+
+      @keyframes pulse {
+        0%, 100% { opacity: 0.5; }
+        50% { opacity: 1; }
+      }
+    `,
+  ],
+})
+export class OnboardingComponent implements OnInit, OnDestroy {
+  readonly #router = inject(Router);
+  readonly #location = inject(Location);
+  readonly #auth = inject(Auth);
+  readonly #onboardingService = inject(OnboardingService);
+  readonly #installationsService = inject(InstallationsService);
+
+  githubConnected = signal(false);
+  appInstalled = signal(false);
+  isLoading = signal(true);
+  isProcessing = signal(false);
+  error = signal<string | null>(null);
+
+  allComplete = computed(() => this.githubConnected() && this.appInstalled());
+
+  readonly installUrl = this.#onboardingService.getGitHubAppInstallUrl();
+
+  readonly githubIcon = `<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>`;
+  readonly repoIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" /></svg>`;
+
+  #subs: Subscription[] = [];
+  #userId: string | null = null;
+
+  ngOnInit() {
+    // Load onboarding state
+    this.#subs.push(
+      this.#onboardingService.getUserId$().subscribe((id) => (this.#userId = id)),
+      this.#onboardingService.hasGitHubAccount$.subscribe((v) => {
+        this.githubConnected.set(v);
+        this.isLoading.set(false);
+      }),
+      this.#onboardingService.hasInstallations$.subscribe((v) => this.appInstalled.set(v)),
+    );
+
+    // Handle GitHub OAuth callback
+    this.#handleOAuthCallback();
+
+    // Handle GitHub App install callback
+    this.#handleInstallCallback();
+  }
+
+  ngOnDestroy() {
+    this.#subs.forEach((s) => s.unsubscribe());
+  }
+
+  connectGitHub() {
+    this.#onboardingService.connectGitHub('/onboarding');
+  }
+
+  skip() {
+    if (this.#userId) {
+      this.#onboardingService.dismissOnboarding(this.#userId).subscribe();
+    }
+    this.#router.navigate(['/hq']);
+  }
+
+  goToDashboard() {
+    this.#router.navigate(['/hq']);
+  }
+
+  goBack() {
+    this.#location.back();
+  }
+
+  #handleOAuthCallback() {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const state = params.get('state');
+
+    if (!code || !state) return;
+
+    const savedState = localStorage.getItem('githubOAuthState');
+    localStorage.removeItem('githubOAuthState');
+
+    window.history.replaceState({}, '', window.location.pathname);
+
+    if (state !== savedState) {
+      this.error.set('GitHub authentication failed. Please try again.');
+      return;
+    }
+
+    this.isProcessing.set(true);
+
+    // Wait for userId to be available
+    this.#onboardingService.getUserId$().pipe(take(1)).subscribe(async (userId) => {
+      if (!userId) {
+        this.error.set('User not found. Please try again.');
+        this.isProcessing.set(false);
+        return;
+      }
+
+      try {
+        const token = await this.#auth.currentUser?.getIdToken();
+        if (!token) throw new Error('Not authenticated');
+
+        const response = await fetch(`${environment.apiUrl}/users/${userId}/connect-github`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code }),
+        });
+
+        if (!response.ok && response.status !== 409) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.error || `Failed: ${response.status}`);
+        }
+
+        this.githubConnected.set(true);
+        this.isProcessing.set(false);
+      } catch (err: any) {
+        this.error.set(`Failed to connect GitHub: ${err?.message || 'Unknown error'}`);
+        this.isProcessing.set(false);
+      }
+    });
+  }
+
+  #handleInstallCallback() {
+    const params = new URLSearchParams(window.location.search);
+    const installationId = params.get('installation_id');
+    const setupAction = params.get('setup_action');
+
+    if (!installationId || !setupAction) return;
+
+    window.history.replaceState({}, '', window.location.pathname);
+    this.isProcessing.set(true);
+
+    this.#installationsService.setupInstallation(Number(installationId), setupAction).subscribe({
+      next: () => {
+        this.appInstalled.set(true);
+        this.isProcessing.set(false);
+      },
+      error: () => {
+        this.appInstalled.set(true); // Might already exist, treat as success
+        this.isProcessing.set(false);
+      },
+    });
+  }
+}

--- a/libs/types/src/lib/user/settings.types.ts
+++ b/libs/types/src/lib/user/settings.types.ts
@@ -4,6 +4,7 @@ export interface UserSettings {
   dailyGoal: number;
   notificationsEnabled: boolean;
   fcmTokens?: string[];
+  onboardingDismissed?: boolean;
   updatedAt: string;
 }
 
@@ -11,6 +12,7 @@ export interface UpdateUserSettingsDto {
   dailyGoal?: number;
   notificationsEnabled?: boolean;
   fcmTokens?: string[];
+  onboardingDismissed?: boolean;
 }
 
 export const DEFAULT_DAILY_GOAL = 8000;


### PR DESCRIPTION
## Summary

Guided two-step onboarding at `/onboarding` for new Framna colleagues:

1. **Connect GitHub** — OAuth redirect to link GitHub account
2. **Install App** — GitHub App install to track repos
3. **Done** — auto-redirect to HQ dashboard

## Features

- Step indicator with progress dots (1 → 2 → done)
- Auto-detects completion: skips already-completed steps
- Handles OAuth callback (`?code=`) and App install callback (`?installation_id=`)
- HQ auto-redirect: new users without GitHub are sent to `/onboarding`
- "Skip for now" dismisses via `onboardingDismissed` setting
- Styled consistently with existing dark theme (cyan/purple accents)

## New files

- `OnboardingService` — centralized onboarding state (GitHub connected, app installed, dismissed)
- `OnboardingComponent` — the onboarding page

## Closes

- #459 — First-login onboarding modal
- #460 — Combined GitHub connect + app install wizard

## Test plan

- [ ] Type checks pass
- [ ] New user (no GitHub account) → HQ redirects to `/onboarding`
- [ ] Step 1: Connect GitHub → OAuth redirect → returns → shows Step 2
- [ ] Step 2: Install App → GitHub App install → returns → shows "All set!"
- [ ] Returning user (GitHub + App done) → goes directly to HQ
- [ ] Skip → goes to HQ, onboarding not shown again
- [ ] Direct URL `/onboarding` → shows correct step based on current state