### PR TITLE
feat(admin-portal): installations overview

### DIFF
--- a/apps/frontend/admin-portal/src/app/app.routes.ts
+++ b/apps/frontend/admin-portal/src/app/app.routes.ts
@@ -35,6 +35,11 @@ export const appRoutes: Routes = [
           import('./pages/users/user-detail.component').then((m) => m.UserDetailComponent),
       },
       {
+        path: 'installations',
+        loadComponent: () =>
+          import('./pages/installations/installations.component').then((m) => m.InstallationsComponent),
+      },
+      {
         path: 'unmatched',
         loadComponent: () =>
           import('./pages/unmatched/unmatched.component').then((m) => m.UnmatchedComponent),

--- a/apps/frontend/admin-portal/src/app/core/services/installations.service.ts
+++ b/apps/frontend/admin-portal/src/app/core/services/installations.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import { Observable, from, shareReplay, switchMap, tap, catchError, throwError } from 'rxjs';
+import { Observable, from, shareReplay, switchMap, catchError, throwError } from 'rxjs';
 import { InstallationSummaryDto } from '@codeheroes/types';
 import { AuthService } from './auth.service';
 import { environment } from '../../../environments/environment';

--- a/apps/frontend/admin-portal/src/app/core/services/installations.service.ts
+++ b/apps/frontend/admin-portal/src/app/core/services/installations.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import { Observable, from, switchMap } from 'rxjs';
+import { Observable, from, shareReplay, switchMap } from 'rxjs';
 import { InstallationSummaryDto } from '@codeheroes/types';
 import { AuthService } from './auth.service';
 import { environment } from '../../../environments/environment';
@@ -10,10 +10,19 @@ export class InstallationsService {
   readonly #http = inject(HttpClient);
   readonly #auth = inject(AuthService);
 
+  #cache$: Observable<InstallationSummaryDto[]> | null = null;
+
   getAllInstallations(): Observable<InstallationSummaryDto[]> {
-    return this.#withAuth((headers) =>
-      this.#http.get<InstallationSummaryDto[]>(`${environment.apiUrl}/installations/admin/all`, { headers }),
-    );
+    if (!this.#cache$) {
+      this.#cache$ = this.#withAuth((headers) =>
+        this.#http.get<InstallationSummaryDto[]>(`${environment.apiUrl}/installations/admin/all`, { headers }),
+      ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+    }
+    return this.#cache$;
+  }
+
+  refreshInstallations(): void {
+    this.#cache$ = null;
   }
 
   #withAuth<T>(fn: (headers: HttpHeaders) => Observable<T>): Observable<T> {

--- a/apps/frontend/admin-portal/src/app/core/services/installations.service.ts
+++ b/apps/frontend/admin-portal/src/app/core/services/installations.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
-import { Observable, from, shareReplay, switchMap } from 'rxjs';
+import { Observable, from, shareReplay, switchMap, tap, catchError, throwError } from 'rxjs';
 import { InstallationSummaryDto } from '@codeheroes/types';
 import { AuthService } from './auth.service';
 import { environment } from '../../../environments/environment';
@@ -16,7 +16,13 @@ export class InstallationsService {
     if (!this.#cache$) {
       this.#cache$ = this.#withAuth((headers) =>
         this.#http.get<InstallationSummaryDto[]>(`${environment.apiUrl}/installations/admin/all`, { headers }),
-      ).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+      ).pipe(
+        catchError((err) => {
+          this.#cache$ = null;
+          return throwError(() => err);
+        }),
+        shareReplay({ bufferSize: 1, refCount: true }),
+      );
     }
     return this.#cache$;
   }

--- a/apps/frontend/admin-portal/src/app/core/services/installations.service.ts
+++ b/apps/frontend/admin-portal/src/app/core/services/installations.service.ts
@@ -1,0 +1,27 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable, from, switchMap } from 'rxjs';
+import { InstallationSummaryDto } from '@codeheroes/types';
+import { AuthService } from './auth.service';
+import { environment } from '../../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class InstallationsService {
+  readonly #http = inject(HttpClient);
+  readonly #auth = inject(AuthService);
+
+  getAllInstallations(): Observable<InstallationSummaryDto[]> {
+    return this.#withAuth((headers) =>
+      this.#http.get<InstallationSummaryDto[]>(`${environment.apiUrl}/installations/admin/all`, { headers }),
+    );
+  }
+
+  #withAuth<T>(fn: (headers: HttpHeaders) => Observable<T>): Observable<T> {
+    return from(this.#auth.getIdToken()).pipe(
+      switchMap((token) => {
+        if (!token) throw new Error('Not authenticated');
+        return fn(new HttpHeaders().set('Authorization', `Bearer ${token}`));
+      }),
+    );
+  }
+}

--- a/apps/frontend/admin-portal/src/app/layout/shell.component.ts
+++ b/apps/frontend/admin-portal/src/app/layout/shell.component.ts
@@ -52,6 +52,16 @@ import { UnmatchedEventsService } from '../core/services/unmatched-events.servic
             Users
           </a>
           <a
+            routerLink="/installations"
+            routerLinkActive="nav-item--active"
+            class="nav-item"
+          >
+            <svg class="nav-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
+            </svg>
+            Installations
+          </a>
+          <a
             routerLink="/unmatched"
             routerLinkActive="nav-item--active"
             class="nav-item"

--- a/apps/frontend/admin-portal/src/app/pages/home/home.component.ts
+++ b/apps/frontend/admin-portal/src/app/pages/home/home.component.ts
@@ -3,6 +3,7 @@ import { RouterLink } from '@angular/router';
 import { forkJoin } from 'rxjs';
 import { ProjectsService } from '../../core/services/projects.service';
 import { DashboardService, LeaderboardEntry } from '../../core/services/dashboard.service';
+import { InstallationsService } from '../../core/services/installations.service';
 import { UnmatchedEventsService } from '../../core/services/unmatched-events.service';
 
 @Component({
@@ -17,7 +18,7 @@ import { UnmatchedEventsService } from '../../core/services/unmatched-events.ser
       @if (isLoading()) {
         <!-- Skeleton: stat cards -->
         <div class="stats-grid">
-          @for (_ of [1, 2, 3, 4, 5]; track $index) {
+          @for (_ of [1, 2, 3, 4, 5, 6]; track $index) {
             <div class="stat-card">
               <div class="skeleton skeleton-label"></div>
               <div class="skeleton skeleton-value"></div>
@@ -65,6 +66,10 @@ import { UnmatchedEventsService } from '../../core/services/unmatched-events.ser
             <span class="stat-label">Total Actions (all projects)</span>
             <span class="stat-value">{{ formatNumber(totalActions()) }}</span>
           </div>
+          <a class="stat-card stat-card--link" routerLink="/installations">
+            <span class="stat-label">Linked Repos</span>
+            <span class="stat-value">{{ linkedRepoCount() }}</span>
+          </a>
           <a class="stat-card stat-card--link" routerLink="/unmatched">
             <span class="stat-label">Unmatched Events</span>
             <span class="stat-value">{{ unmatchedCount() }}</span>
@@ -341,12 +346,14 @@ import { UnmatchedEventsService } from '../../core/services/unmatched-events.ser
 export class HomeComponent implements OnInit {
   readonly #projectsService = inject(ProjectsService);
   readonly #dashboardService = inject(DashboardService);
+  readonly #installationsService = inject(InstallationsService);
   readonly #unmatchedEventsService = inject(UnmatchedEventsService);
 
   readonly projectCount = signal(0);
   readonly userCountLabel = signal('0');
   readonly totalXp = signal(0);
   readonly totalActions = signal(0);
+  readonly linkedRepoCount = signal(0);
   readonly unmatchedCount = signal(0);
   readonly leaderboard = signal<LeaderboardEntry[]>([]);
   readonly leaderboardTop = computed(() => this.leaderboard().slice(0, 5));
@@ -357,14 +364,16 @@ export class HomeComponent implements OnInit {
     forkJoin({
       projects: this.#projectsService.getProjects(),
       leaderboard: this.#dashboardService.getWeeklyLeaderboard(),
+      installations: this.#installationsService.getAllInstallations(),
       unmatched: this.#unmatchedEventsService.getSummary(),
     }).subscribe({
-      next: ({ projects, leaderboard, unmatched }) => {
+      next: ({ projects, leaderboard, installations, unmatched }) => {
         this.projectCount.set(projects.length);
         this.totalXp.set(projects.reduce((sum, p) => sum + p.totalXp, 0));
         this.totalActions.set(projects.reduce((sum, p) => sum + p.totalActions, 0));
         this.userCountLabel.set(String(leaderboard.length));
         this.leaderboard.set(leaderboard);
+        this.linkedRepoCount.set(installations.reduce((sum, i) => sum + i.repositoryCount, 0));
         this.unmatchedCount.set(unmatched.unknownUserCount + unmatched.unlinkedRepoCount);
         this.isLoading.set(false);
       },

--- a/apps/frontend/admin-portal/src/app/pages/installations/installations.component.ts
+++ b/apps/frontend/admin-portal/src/app/pages/installations/installations.component.ts
@@ -17,7 +17,7 @@ import { UsersService } from '../../core/services/users.service';
       <p class="page-subtitle">
         @if (!isLoading() && !error()) {
           {{ filteredInstallations().length }} installation{{ filteredInstallations().length !== 1 ? 's' : '' }}
-          · {{ totalRepoCount() }} linked repositories
+          · {{ filteredRepoCount() }} linked repositories
         } @else {
           GitHub App installations overview
         }
@@ -87,7 +87,11 @@ import { UsersService } from '../../core/services/users.service';
               </thead>
               <tbody>
                 @for (inst of filteredInstallations(); track inst.id) {
-                  <tr class="clickable-row" (click)="toggleExpanded(inst.id)">
+                  <tr class="clickable-row" role="button" tabindex="0"
+                      (click)="toggleExpanded(inst.id)"
+                      (keydown.enter)="toggleExpanded(inst.id)"
+                      (keydown.space)="toggleExpanded(inst.id); $event.preventDefault()"
+                      [attr.aria-expanded]="expandedId() === inst.id">
                     <td>
                       <div class="account-cell">
                         <div class="account-avatar">{{ inst.accountLogin.charAt(0).toUpperCase() }}</div>
@@ -516,6 +520,10 @@ export class InstallationsComponent implements OnInit {
 
   readonly totalRepoCount = computed(() =>
     this.installations().reduce((sum, i) => sum + i.repositoryCount, 0),
+  );
+
+  readonly filteredRepoCount = computed(() =>
+    this.filteredInstallations().reduce((sum, i) => sum + i.repositoryCount, 0),
   );
 
   ngOnInit(): void {

--- a/apps/frontend/admin-portal/src/app/pages/installations/installations.component.ts
+++ b/apps/frontend/admin-portal/src/app/pages/installations/installations.component.ts
@@ -1,0 +1,556 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { SuiButtonComponent } from '@move4mobile/stride-ui';
+import { InstallationSummaryDto } from '@codeheroes/types';
+import { forkJoin } from 'rxjs';
+import { InstallationsService } from '../../core/services/installations.service';
+import { UsersService } from '../../core/services/users.service';
+
+@Component({
+  selector: 'admin-installations',
+  standalone: true,
+  imports: [DatePipe, RouterLink, SuiButtonComponent],
+  template: `
+    <div>
+      <h1 class="page-title">Installations</h1>
+      <p class="page-subtitle">
+        @if (!isLoading() && !error()) {
+          {{ filteredInstallations().length }} installation{{ filteredInstallations().length !== 1 ? 's' : '' }}
+          · {{ totalRepoCount() }} linked repositories
+        } @else {
+          GitHub App installations overview
+        }
+      </p>
+
+      @if (isLoading()) {
+        <div class="table-container">
+          <div class="skeleton-table">
+            @for (_ of [1, 2, 3, 4, 5]; track $index) {
+              <div class="skeleton-row">
+                <div class="skeleton skeleton-avatar-ph"></div>
+                <div class="skeleton skeleton-name"></div>
+                <div class="skeleton skeleton-badge"></div>
+                <div class="skeleton skeleton-number"></div>
+                <div class="skeleton skeleton-name"></div>
+                <div class="skeleton skeleton-date"></div>
+              </div>
+            }
+          </div>
+        </div>
+      } @else if (error()) {
+        <div class="error-state">
+          <p>{{ error() }}</p>
+          <sui-button variant="outline" color="neutral" size="sm" (click)="load()">
+            Try again
+          </sui-button>
+        </div>
+      } @else {
+        <div class="toolbar">
+          <input
+            class="search-input"
+            type="text"
+            placeholder="Search account or repository..."
+            [value]="searchTerm()"
+            (input)="onSearch($event)"
+          />
+          <div class="filter-pills">
+            @for (f of statusFilters; track f.value) {
+              <button
+                class="filter-pill"
+                [class.filter-pill--active]="statusFilter() === f.value"
+                (click)="statusFilter.set(f.value)"
+              >
+                {{ f.label }}
+              </button>
+            }
+          </div>
+        </div>
+
+        @if (filteredInstallations().length === 0) {
+          <div class="empty-state">
+            <p>No installations found.</p>
+          </div>
+        } @else {
+          <div class="table-container">
+            <table class="installations-table">
+              <thead>
+                <tr>
+                  <th>Account</th>
+                  <th>Repositories</th>
+                  <th>Status</th>
+                  <th>Linked User</th>
+                  <th>Linked At</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (inst of filteredInstallations(); track inst.id) {
+                  <tr class="clickable-row" (click)="toggleExpanded(inst.id)">
+                    <td>
+                      <div class="account-cell">
+                        <div class="account-avatar">{{ inst.accountLogin.charAt(0).toUpperCase() }}</div>
+                        <span class="account-login">{{ inst.accountLogin }}</span>
+                        <span class="type-badge">{{ inst.accountType }}</span>
+                      </div>
+                    </td>
+                    <td>
+                      @if (inst.repositorySelection === 'all') {
+                        <span class="repo-all-badge">All repositories</span>
+                      } @else {
+                        <span>{{ inst.repositoryCount }}</span>
+                        @if (inst.repositories.length > 0) {
+                          <span class="repo-preview">
+                            — {{ repoPreview(inst) }}
+                          </span>
+                        }
+                      }
+                    </td>
+                    <td>
+                      <span class="status-badge status-{{ inst.status }}">{{ inst.status }}</span>
+                    </td>
+                    <td>
+                      @if (inst.linkedUserId) {
+                        <a class="user-link" [routerLink]="['/users', inst.linkedUserId]" (click)="$event.stopPropagation()">
+                          {{ userNameMap()[inst.linkedUserId] || inst.linkedUserId }}
+                        </a>
+                      } @else {
+                        <span class="unlinked">Unlinked</span>
+                      }
+                    </td>
+                    <td>
+                      @if (inst.linkedAt) {
+                        {{ inst.linkedAt | date: 'mediumDate' }}
+                      } @else {
+                        —
+                      }
+                    </td>
+                  </tr>
+                  @if (expandedId() === inst.id && inst.repositorySelection !== 'all' && inst.repositories.length > 0) {
+                    <tr class="expanded-row">
+                      <td colspan="5">
+                        <div class="repo-list">
+                          @for (repo of inst.repositories; track repo.id) {
+                            <div class="repo-item">
+                              <span class="repo-name">{{ repo.fullName }}</span>
+                              <span class="visibility-badge" [class.visibility-private]="repo.private">
+                                {{ repo.private ? 'private' : 'public' }}
+                              </span>
+                            </div>
+                          }
+                        </div>
+                      </td>
+                    </tr>
+                  }
+                }
+              </tbody>
+            </table>
+          </div>
+        }
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .page-title {
+        font-size: 24px;
+        font-weight: 700;
+        color: var(--theme-color-text-default);
+        margin-bottom: 4px;
+      }
+
+      .page-subtitle {
+        font-size: 14px;
+        color: var(--theme-color-text-neutral-tertiary);
+        margin-bottom: 24px;
+      }
+
+      .toolbar {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        margin-bottom: 16px;
+        flex-wrap: wrap;
+      }
+
+      .search-input {
+        flex: 1;
+        min-width: 200px;
+        max-width: 320px;
+        padding: 8px 12px;
+        border: 1px solid var(--theme-color-border-default-default);
+        border-radius: 6px;
+        font-size: 14px;
+        color: var(--theme-color-text-default);
+        background: var(--theme-color-bg-surface-default);
+      }
+
+      .search-input:focus {
+        outline: none;
+        border-color: var(--theme-color-border-brand-default);
+      }
+
+      .search-input::placeholder {
+        color: var(--theme-color-text-neutral-tertiary);
+      }
+
+      .filter-pills {
+        display: flex;
+        gap: 4px;
+      }
+
+      .filter-pill {
+        padding: 4px 12px;
+        border: 1px solid var(--theme-color-border-default-default);
+        border-radius: 16px;
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--theme-color-text-neutral-tertiary);
+        background: transparent;
+        cursor: pointer;
+        transition: all 0.15s ease;
+        font-family: inherit;
+      }
+
+      .filter-pill:hover {
+        color: var(--theme-color-text-default);
+        background: var(--theme-color-bg-neutral-secondary);
+      }
+
+      .filter-pill--active {
+        background: var(--theme-color-bg-brand-secondary);
+        color: var(--theme-color-text-brand-default);
+        border-color: var(--theme-color-border-brand-default);
+      }
+
+      .table-container {
+        background: var(--theme-color-bg-surface-default);
+        border: 1px solid var(--theme-color-border-default-default);
+        border-radius: 8px;
+        overflow: hidden;
+      }
+
+      .installations-table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      .installations-table th {
+        text-align: left;
+        padding: 12px 16px;
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--theme-color-text-neutral-tertiary);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        border-bottom: 1px solid var(--theme-color-border-default-default);
+        background: var(--theme-color-bg-neutral-secondary);
+      }
+
+      .installations-table td {
+        padding: 12px 16px;
+        font-size: 14px;
+        color: var(--theme-color-text-default);
+        border-bottom: 1px solid var(--theme-color-border-default-default);
+      }
+
+      .installations-table tr:last-child td {
+        border-bottom: none;
+      }
+
+      .clickable-row {
+        cursor: pointer;
+      }
+
+      .clickable-row:hover td {
+        background: var(--theme-color-bg-neutral-secondary);
+      }
+
+      .account-cell {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .account-avatar {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background: var(--theme-color-bg-neutral-secondary);
+        color: var(--theme-color-text-brand-default);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+        font-size: 12px;
+        flex-shrink: 0;
+      }
+
+      .account-login {
+        font-weight: 500;
+      }
+
+      .type-badge {
+        display: inline-block;
+        padding: 1px 6px;
+        border-radius: 4px;
+        font-size: 11px;
+        font-weight: 500;
+        background: var(--theme-color-bg-neutral-secondary);
+        color: var(--theme-color-text-neutral-secondary);
+      }
+
+      .status-badge {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 500;
+        text-transform: capitalize;
+      }
+
+      .status-active {
+        background: var(--theme-color-feedback-bg-success-secondary, var(--theme-color-bg-brand-secondary));
+        color: var(--theme-color-feedback-text-success-default, var(--theme-color-text-brand-default));
+      }
+
+      .status-suspended {
+        background: var(--theme-color-feedback-bg-warning-secondary, #fef3c7);
+        color: var(--theme-color-feedback-text-warning-default, #92400e);
+      }
+
+      .status-deleted {
+        background: var(--theme-color-feedback-bg-error-secondary);
+        color: var(--theme-color-feedback-text-error-default);
+      }
+
+      .repo-all-badge {
+        font-style: italic;
+        color: var(--theme-color-text-neutral-tertiary);
+      }
+
+      .repo-preview {
+        font-size: 13px;
+        color: var(--theme-color-text-neutral-tertiary);
+      }
+
+      .user-link {
+        color: var(--theme-color-text-brand-default);
+        text-decoration: none;
+        font-weight: 500;
+      }
+
+      .user-link:hover {
+        text-decoration: underline;
+      }
+
+      .unlinked {
+        color: var(--theme-color-text-neutral-tertiary);
+        font-style: italic;
+      }
+
+      .expanded-row td {
+        padding: 0 16px 16px;
+        background: var(--theme-color-bg-neutral-secondary);
+      }
+
+      .repo-list {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding: 12px 0 0 38px;
+      }
+
+      .repo-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+      }
+
+      .repo-name {
+        font-family: monospace;
+        font-size: 13px;
+        color: var(--theme-color-text-default);
+      }
+
+      .visibility-badge {
+        display: inline-block;
+        padding: 1px 6px;
+        border-radius: 4px;
+        font-size: 11px;
+        font-weight: 500;
+        background: var(--theme-color-bg-neutral-secondary);
+        color: var(--theme-color-text-neutral-secondary);
+      }
+
+      .visibility-private {
+        background: var(--theme-color-feedback-bg-warning-secondary, #fef3c7);
+        color: var(--theme-color-feedback-text-warning-default, #92400e);
+      }
+
+      .loading-state,
+      .empty-state {
+        text-align: center;
+        padding: 48px 0;
+        color: var(--theme-color-text-neutral-tertiary);
+        font-size: 14px;
+      }
+
+      .error-state {
+        background: var(--theme-color-feedback-bg-error-secondary);
+        border: 1px solid var(--theme-color-feedback-border-error-default);
+        border-radius: 8px;
+        padding: 16px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        color: var(--theme-color-feedback-text-error-default);
+        font-size: 14px;
+      }
+
+      /* Skeleton loader */
+      @keyframes shimmer {
+        0% { opacity: 1; }
+        50% { opacity: 0.4; }
+        100% { opacity: 1; }
+      }
+
+      .skeleton {
+        background: var(--theme-color-bg-neutral-secondary);
+        border-radius: 4px;
+        animation: shimmer 1.5s ease-in-out infinite;
+      }
+
+      .skeleton-table {
+        padding: 12px 0;
+      }
+
+      .skeleton-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 16px;
+      }
+
+      .skeleton-avatar-ph {
+        height: 28px;
+        width: 28px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+
+      .skeleton-name {
+        height: 16px;
+        width: 120px;
+        flex-shrink: 0;
+      }
+
+      .skeleton-badge {
+        height: 16px;
+        width: 48px;
+        flex-shrink: 0;
+      }
+
+      .skeleton-number {
+        height: 16px;
+        width: 36px;
+        flex-shrink: 0;
+      }
+
+      .skeleton-date {
+        height: 16px;
+        width: 80px;
+        flex-shrink: 0;
+        margin-left: auto;
+      }
+    `,
+  ],
+})
+export class InstallationsComponent implements OnInit {
+  readonly #installationsService = inject(InstallationsService);
+  readonly #usersService = inject(UsersService);
+
+  readonly installations = signal<InstallationSummaryDto[]>([]);
+  readonly userNameMap = signal<Record<string, string>>({});
+  readonly isLoading = signal(true);
+  readonly error = signal<string | null>(null);
+  readonly searchTerm = signal('');
+  readonly statusFilter = signal<string | null>(null);
+  readonly expandedId = signal<string | null>(null);
+
+  readonly statusFilters = [
+    { label: 'All', value: null },
+    { label: 'Active', value: 'active' },
+    { label: 'Suspended', value: 'suspended' },
+    { label: 'Deleted', value: 'deleted' },
+  ];
+
+  readonly filteredInstallations = computed(() => {
+    let list = this.installations();
+    const status = this.statusFilter();
+    const search = this.searchTerm().toLowerCase().trim();
+
+    if (status) {
+      list = list.filter((i) => i.status === status);
+    }
+
+    if (search) {
+      list = list.filter(
+        (i) =>
+          i.accountLogin.toLowerCase().includes(search) ||
+          i.repositories.some((r) => r.fullName.toLowerCase().includes(search)),
+      );
+    }
+
+    return list;
+  });
+
+  readonly totalRepoCount = computed(() =>
+    this.installations().reduce((sum, i) => sum + i.repositoryCount, 0),
+  );
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.isLoading.set(true);
+    this.error.set(null);
+
+    forkJoin({
+      installations: this.#installationsService.getAllInstallations(),
+      users: this.#usersService.getUsers({ limit: 200 }),
+    }).subscribe({
+      next: ({ installations, users }) => {
+        this.installations.set(installations);
+        const nameMap: Record<string, string> = {};
+        for (const u of users.items) {
+          nameMap[u.id] = u.displayName || u.name || u.email || u.id;
+        }
+        this.userNameMap.set(nameMap);
+        this.isLoading.set(false);
+      },
+      error: () => {
+        this.error.set('Failed to load installations.');
+        this.isLoading.set(false);
+      },
+    });
+  }
+
+  onSearch(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.searchTerm.set(value);
+  }
+
+  toggleExpanded(id: string): void {
+    this.expandedId.update((current) => (current === id ? null : id));
+  }
+
+  repoPreview(inst: InstallationSummaryDto): string {
+    const repos = inst.repositories;
+    if (repos.length <= 3) {
+      return repos.map((r) => r.name).join(', ');
+    }
+    return repos.slice(0, 2).map((r) => r.name).join(', ') + ` +${repos.length - 2} more`;
+  }
+}

--- a/apps/frontend/admin-portal/src/app/pages/installations/installations.component.ts
+++ b/apps/frontend/admin-portal/src/app/pages/installations/installations.component.ts
@@ -87,11 +87,7 @@ import { UsersService } from '../../core/services/users.service';
               </thead>
               <tbody>
                 @for (inst of filteredInstallations(); track inst.id) {
-                  <tr class="clickable-row" role="button" tabindex="0"
-                      (click)="toggleExpanded(inst.id)"
-                      (keydown.enter)="toggleExpanded(inst.id)"
-                      (keydown.space)="toggleExpanded(inst.id); $event.preventDefault()"
-                      [attr.aria-expanded]="expandedId() === inst.id">
+                  <tr>
                     <td>
                       <div class="account-cell">
                         <div class="account-avatar">{{ inst.accountLogin.charAt(0).toUpperCase() }}</div>
@@ -103,11 +99,25 @@ import { UsersService } from '../../core/services/users.service';
                       @if (inst.repositorySelection === 'all') {
                         <span class="repo-all-badge">All repositories</span>
                       } @else {
-                        <span>{{ inst.repositoryCount }}</span>
-                        @if (inst.repositories.length > 0) {
-                          <span class="repo-preview">
-                            — {{ repoPreview(inst) }}
-                          </span>
+                        <button class="repo-toggle" role="button" tabindex="0"
+                            (click)="toggleExpanded(inst.id)"
+                            (keydown.enter)="toggleExpanded(inst.id)"
+                            (keydown.space)="toggleExpanded(inst.id); $event.preventDefault()"
+                            [attr.aria-expanded]="expandedId() === inst.id">
+                          <span class="repo-toggle-icon" [class.repo-toggle-icon--open]="expandedId() === inst.id">&#9656;</span>
+                          {{ inst.repositoryCount }} repo{{ inst.repositoryCount !== 1 ? 's' : '' }}
+                        </button>
+                        @if (expandedId() === inst.id && inst.repositories.length > 0) {
+                          <div class="repo-list">
+                            @for (repo of inst.repositories; track repo.id) {
+                              <div class="repo-item">
+                                <span class="repo-name">{{ repo.name }}</span>
+                                <span class="visibility-badge" [class.visibility-private]="repo.private">
+                                  {{ repo.private ? 'private' : 'public' }}
+                                </span>
+                              </div>
+                            }
+                          </div>
                         }
                       }
                     </td>
@@ -116,7 +126,7 @@ import { UsersService } from '../../core/services/users.service';
                     </td>
                     <td>
                       @if (inst.linkedUserId) {
-                        <a class="user-link" [routerLink]="['/users', inst.linkedUserId]" (click)="$event.stopPropagation()">
+                        <a class="user-link" [routerLink]="['/users', inst.linkedUserId]">
                           {{ userNameMap()[inst.linkedUserId] || inst.linkedUserId }}
                         </a>
                       } @else {
@@ -131,22 +141,6 @@ import { UsersService } from '../../core/services/users.service';
                       }
                     </td>
                   </tr>
-                  @if (expandedId() === inst.id && inst.repositorySelection !== 'all' && inst.repositories.length > 0) {
-                    <tr class="expanded-row">
-                      <td colspan="5">
-                        <div class="repo-list">
-                          @for (repo of inst.repositories; track repo.id) {
-                            <div class="repo-item">
-                              <span class="repo-name">{{ repo.fullName }}</span>
-                              <span class="visibility-badge" [class.visibility-private]="repo.private">
-                                {{ repo.private ? 'private' : 'public' }}
-                              </span>
-                            </div>
-                          }
-                        </div>
-                      </td>
-                    </tr>
-                  }
                 }
               </tbody>
             </table>
@@ -263,12 +257,31 @@ import { UsersService } from '../../core/services/users.service';
         border-bottom: none;
       }
 
-      .clickable-row {
+      .repo-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 0;
+        border: none;
+        background: none;
+        font-family: inherit;
+        font-size: 14px;
+        color: var(--theme-color-text-brand-default);
         cursor: pointer;
       }
 
-      .clickable-row:hover td {
-        background: var(--theme-color-bg-neutral-secondary);
+      .repo-toggle:hover {
+        text-decoration: underline;
+      }
+
+      .repo-toggle-icon {
+        display: inline-block;
+        font-size: 10px;
+        transition: transform 0.15s ease;
+      }
+
+      .repo-toggle-icon--open {
+        transform: rotate(90deg);
       }
 
       .account-cell {
@@ -354,16 +367,12 @@ import { UsersService } from '../../core/services/users.service';
         font-style: italic;
       }
 
-      .expanded-row td {
-        padding: 0 16px 16px;
-        background: var(--theme-color-bg-neutral-secondary);
-      }
-
       .repo-list {
         display: flex;
         flex-direction: column;
-        gap: 6px;
-        padding: 12px 0 0 38px;
+        gap: 4px;
+        margin-top: 8px;
+        padding-left: 14px;
       }
 
       .repo-item {

--- a/apps/frontend/admin-portal/src/app/pages/installations/installations.component.ts
+++ b/apps/frontend/admin-portal/src/app/pages/installations/installations.component.ts
@@ -54,8 +54,9 @@ import { UsersService } from '../../core/services/users.service';
             [value]="searchTerm()"
             (input)="onSearch($event)"
           />
+          @if (hasMultipleStatuses()) {
           <div class="filter-pills">
-            @for (f of statusFilters; track f.value) {
+            @for (f of statusFilters(); track f.value) {
               <button
                 class="filter-pill"
                 [class.filter-pill--active]="statusFilter() === f.value"
@@ -65,6 +66,7 @@ import { UsersService } from '../../core/services/users.service';
               </button>
             }
           </div>
+          }
         </div>
 
         @if (filteredInstallations().length === 0) {
@@ -478,12 +480,19 @@ export class InstallationsComponent implements OnInit {
   readonly statusFilter = signal<string | null>(null);
   readonly expandedId = signal<string | null>(null);
 
-  readonly statusFilters = [
-    { label: 'All', value: null },
-    { label: 'Active', value: 'active' },
-    { label: 'Suspended', value: 'suspended' },
-    { label: 'Deleted', value: 'deleted' },
-  ];
+  readonly hasMultipleStatuses = computed(() => {
+    const statuses = new Set(this.installations().map((i) => i.status));
+    return statuses.size > 1;
+  });
+
+  readonly statusFilters = computed(() => {
+    const statuses = new Set(this.installations().map((i) => i.status));
+    const filters: { label: string; value: string | null }[] = [{ label: 'All', value: null }];
+    if (statuses.has('active')) filters.push({ label: 'Active', value: 'active' });
+    if (statuses.has('suspended')) filters.push({ label: 'Suspended', value: 'suspended' });
+    if (statuses.has('deleted')) filters.push({ label: 'Deleted', value: 'deleted' });
+    return filters;
+  });
 
   readonly filteredInstallations = computed(() => {
     let list = this.installations();

--- a/apps/frontend/admin-portal/src/app/pages/installations/installations.component.ts
+++ b/apps/frontend/admin-portal/src/app/pages/installations/installations.component.ts
@@ -99,10 +99,8 @@ import { UsersService } from '../../core/services/users.service';
                       @if (inst.repositorySelection === 'all') {
                         <span class="repo-all-badge">All repositories</span>
                       } @else {
-                        <button class="repo-toggle" role="button" tabindex="0"
+                        <button class="repo-toggle"
                             (click)="toggleExpanded(inst.id)"
-                            (keydown.enter)="toggleExpanded(inst.id)"
-                            (keydown.space)="toggleExpanded(inst.id); $event.preventDefault()"
                             [attr.aria-expanded]="expandedId() === inst.id">
                           <span class="repo-toggle-icon" [class.repo-toggle-icon--open]="expandedId() === inst.id">&#9656;</span>
                           {{ inst.repositoryCount }} repo{{ inst.repositoryCount !== 1 ? 's' : '' }}
@@ -347,11 +345,6 @@ import { UsersService } from '../../core/services/users.service';
         color: var(--theme-color-text-neutral-tertiary);
       }
 
-      .repo-preview {
-        font-size: 13px;
-        color: var(--theme-color-text-neutral-tertiary);
-      }
-
       .user-link {
         color: var(--theme-color-text-brand-default);
         text-decoration: none;
@@ -527,10 +520,6 @@ export class InstallationsComponent implements OnInit {
     return list;
   });
 
-  readonly totalRepoCount = computed(() =>
-    this.installations().reduce((sum, i) => sum + i.repositoryCount, 0),
-  );
-
   readonly filteredRepoCount = computed(() =>
     this.filteredInstallations().reduce((sum, i) => sum + i.repositoryCount, 0),
   );
@@ -572,11 +561,4 @@ export class InstallationsComponent implements OnInit {
     this.expandedId.update((current) => (current === id ? null : id));
   }
 
-  repoPreview(inst: InstallationSummaryDto): string {
-    const repos = inst.repositories;
-    if (repos.length <= 3) {
-      return repos.map((r) => r.name).join(', ');
-    }
-    return repos.slice(0, 2).map((r) => r.name).join(', ') + ` +${repos.length - 2} more`;
-  }
 }

--- a/apps/frontend/admin-portal/src/app/pages/users/user-detail.component.ts
+++ b/apps/frontend/admin-portal/src/app/pages/users/user-detail.component.ts
@@ -3,8 +3,9 @@ import { DatePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { SuiButtonComponent } from '@move4mobile/stride-ui';
-import { ConnectedAccountDto, ConnectedAccountProvider, CONNECTED_ACCOUNT_PROVIDERS, UserDto, UserRole } from '@codeheroes/types';
+import { ConnectedAccountDto, ConnectedAccountProvider, CONNECTED_ACCOUNT_PROVIDERS, InstallationSummaryDto, UserDto, UserRole } from '@codeheroes/types';
 import { UsersService } from '../../core/services/users.service';
+import { InstallationsService } from '../../core/services/installations.service';
 
 @Component({
   selector: 'admin-user-detail',
@@ -236,6 +237,56 @@ import { UsersService } from '../../core/services/users.service';
                           Remove
                         </sui-button>
                       </td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </div>
+          }
+        </div>
+
+        <div class="section">
+          <div class="section-header">
+            <h2 class="section-title">GitHub Installations</h2>
+          </div>
+
+          @if (installationsLoading()) {
+            <div class="loading-state">
+              <p>Loading installations...</p>
+            </div>
+          } @else if (userInstallations().length === 0) {
+            <div class="empty-state">
+              <p>No GitHub installations linked.</p>
+            </div>
+          } @else {
+            <div class="table-container">
+              <table class="accounts-table">
+                <thead>
+                  <tr>
+                    <th>Account</th>
+                    <th>Repositories</th>
+                    <th>Status</th>
+                    <th>Linked At</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  @for (inst of userInstallations(); track inst.id) {
+                    <tr>
+                      <td>
+                        <span class="account-login">{{ inst.accountLogin }}</span>
+                        <span class="type-badge">{{ inst.accountType }}</span>
+                      </td>
+                      <td>
+                        @if (inst.repositorySelection === 'all') {
+                          <span class="repo-all">All repositories</span>
+                        } @else {
+                          {{ inst.repositoryCount }} repo{{ inst.repositoryCount !== 1 ? 's' : '' }}
+                        }
+                      </td>
+                      <td>
+                        <span class="installation-status-badge installation-status-{{ inst.status }}">{{ inst.status }}</span>
+                      </td>
+                      <td>{{ inst.linkedAt | date: 'mediumDate' }}</td>
                     </tr>
                   }
                 </tbody>
@@ -579,6 +630,50 @@ import { UsersService } from '../../core/services/users.service';
         font-size: 13px;
         color: var(--theme-color-text-neutral-tertiary);
       }
+
+      .account-login {
+        font-weight: 500;
+        margin-right: 8px;
+      }
+
+      .type-badge {
+        display: inline-block;
+        padding: 1px 6px;
+        border-radius: 4px;
+        font-size: 11px;
+        font-weight: 500;
+        background: var(--theme-color-bg-neutral-secondary);
+        color: var(--theme-color-text-neutral-secondary);
+      }
+
+      .repo-all {
+        font-style: italic;
+        color: var(--theme-color-text-neutral-tertiary);
+      }
+
+      .installation-status-badge {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 500;
+        text-transform: capitalize;
+      }
+
+      .installation-status-active {
+        background: var(--theme-color-feedback-bg-success-secondary, var(--theme-color-bg-brand-secondary));
+        color: var(--theme-color-feedback-text-success-default, var(--theme-color-text-brand-default));
+      }
+
+      .installation-status-suspended {
+        background: var(--theme-color-feedback-bg-warning-secondary, #fef3c7);
+        color: var(--theme-color-feedback-text-warning-default, #92400e);
+      }
+
+      .installation-status-deleted {
+        background: var(--theme-color-feedback-bg-error-secondary);
+        color: var(--theme-color-feedback-text-error-default);
+      }
     `,
   ],
 })
@@ -586,9 +681,12 @@ export class UserDetailComponent implements OnInit {
   readonly #route = inject(ActivatedRoute);
   readonly #router = inject(Router);
   readonly #usersService = inject(UsersService);
+  readonly #installationsService = inject(InstallationsService);
 
   readonly user = signal<UserDto | null>(null);
   readonly accounts = signal<ConnectedAccountDto[]>([]);
+  readonly userInstallations = signal<InstallationSummaryDto[]>([]);
+  readonly installationsLoading = signal(true);
   readonly isLoading = signal(true);
   readonly accountsLoading = signal(true);
   readonly error = signal<string | null>(null);
@@ -620,6 +718,20 @@ export class UserDetailComponent implements OnInit {
     this.#userId = this.#route.snapshot.params['id'];
     this.loadUser();
     this.loadAccounts();
+    this.loadInstallations();
+  }
+
+  loadInstallations(): void {
+    this.installationsLoading.set(true);
+    this.#installationsService.getAllInstallations().subscribe({
+      next: (all) => {
+        this.userInstallations.set(all.filter((i) => i.linkedUserId === this.#userId));
+        this.installationsLoading.set(false);
+      },
+      error: () => {
+        this.installationsLoading.set(false);
+      },
+    });
   }
 
   hasChanges(): boolean {

--- a/apps/frontend/admin-portal/src/app/pages/users/user-detail.component.ts
+++ b/apps/frontend/admin-portal/src/app/pages/users/user-detail.component.ts
@@ -254,6 +254,13 @@ import { InstallationsService } from '../../core/services/installations.service'
             <div class="loading-state">
               <p>Loading installations...</p>
             </div>
+          } @else if (installationsError()) {
+            <div class="error-state">
+              <p>{{ installationsError() }}</p>
+              <sui-button variant="outline" color="neutral" size="sm" (click)="loadInstallations()">
+                Try again
+              </sui-button>
+            </div>
           } @else if (userInstallations().length === 0) {
             <div class="empty-state">
               <p>No GitHub installations linked.</p>
@@ -687,6 +694,7 @@ export class UserDetailComponent implements OnInit {
   readonly accounts = signal<ConnectedAccountDto[]>([]);
   readonly userInstallations = signal<InstallationSummaryDto[]>([]);
   readonly installationsLoading = signal(true);
+  readonly installationsError = signal<string | null>(null);
   readonly isLoading = signal(true);
   readonly accountsLoading = signal(true);
   readonly error = signal<string | null>(null);
@@ -723,12 +731,14 @@ export class UserDetailComponent implements OnInit {
 
   loadInstallations(): void {
     this.installationsLoading.set(true);
+    this.installationsError.set(null);
     this.#installationsService.getAllInstallations().subscribe({
       next: (all) => {
         this.userInstallations.set(all.filter((i) => i.linkedUserId === this.#userId));
         this.installationsLoading.set(false);
       },
       error: () => {
+        this.installationsError.set('Failed to load installations.');
         this.installationsLoading.set(false);
       },
     });


### PR DESCRIPTION
## Summary

Adds GitHub App installation visibility to the admin portal — admins can now see which repositories are linked across the platform, by whom, and with what status.

### Changes

- **New `/installations` page** — table with search, dynamic status filters, inline repo list toggle with public/private badges
- **Dashboard stat card** — "Linked Repos" count linking to the installations page
- **User detail section** — "GitHub Installations" section below Connected Accounts showing per-user installations
- **Caching** — `InstallationsService` caches with `shareReplay` to avoid repeated fetches across pages

### Technical notes

- Uses existing `GET /installations/admin/all` backend endpoint — no backend changes needed
- `InstallationsService` follows the same `#withAuth` pattern as other admin-portal services
- User name resolution via `UsersService.getUsers()` lookup map
- Client-side filtering (max 500 installations from backend)
- Status filter pills only shown when multiple statuses exist in the data
- Cache auto-clears on error to prevent stale error replay

## Test plan

- [x] `/installations` page loads and shows all installations
- [x] Search filters by account login and repository name
- [x] Status filter pills shown only when multiple statuses exist
- [x] Clicking repo count toggles inline repository list
- [x] "Linked User" column links to correct user detail page
- [x] `/home` dashboard shows "Linked Repos" stat card
- [x] Clicking stat card navigates to `/installations`
- [x] `/users/:id` shows "GitHub Installations" section
- [ ] Dark mode renders correctly
- [x] Build passes without errors