### PR TITLE
chore(deps): bump @move4mobile/stride-ui from 1.17.0 to 1.17.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9358,9 +9358,9 @@
       }
     },
     "node_modules/@move4mobile/stride-ui": {
-      "version": "1.17.0",
-      "resolved": "https://npm.pkg.github.com/download/@move4mobile/stride-ui/1.17.0/f8904b88506b4c4f1e46ba830617a213c26577dc",
-      "integrity": "sha512-de4sfRwRTj6KwljUhn19EGWE2raRinjp3gcS3Re8SdAbXZHSYVqss6iWU3SKZq5hggHvK3uW3BfQr7EIl/Pj4Q==",
+      "version": "1.17.2",
+      "resolved": "https://npm.pkg.github.com/download/@move4mobile/stride-ui/1.17.2/acb5ac77c83a0140fc1753cf6d8449888c3f472e",
+      "integrity": "sha512-fHq1k4Ig8ocK1qhnqpvN5m5OMH08NGeUeAzt5pmQAU/6Cv1Du0rDruJMVRasikzCuOz6jYN/4srk81U4JFPxOg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },


### PR DESCRIPTION
## Summary
- Bumps `@move4mobile/stride-ui` from `1.17.0` → `1.17.2` (2 patch releases)
- Semver range `^1.17.0` already accepts this, so only `package-lock.json` changes

## Verification
- [x] `nx build admin-portal --configuration=production` succeeds
- [x] No new warnings or errors (pre-existing CSS budget / quill CommonJS warnings unchanged)

## Release timeline
| Version | Released |
|---------|----------|
| 1.17.0 (current) | 2026-02-06 |
| 1.17.1 | 2026-02-11 |
| 1.17.2 (new) | 2026-02-18 |