### PR TITLE
chore(deps): bundle dependabot minor+patch updates by dep type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,67 +12,16 @@ updates:
     ignore:
       - dependency-name: '@move4mobile*'
     groups:
-      angular:
-        applies-to: version-updates
-        patterns:
-          - '@angular*'
-          - '@schematics/angular'
-          - 'zone.js'
-      nx:
-        applies-to: version-updates
-        patterns:
-          - '@nx/*'
-          - 'nx*'
-      firebase:
-        applies-to: version-updates
-        patterns:
-          - 'firebase'
-          - 'firebase-*'
-          - '@angular/fire'
-          - '@firebase/*'
-      firebase-admin:
-        applies-to: version-updates
-        patterns:
-          - 'firebase-admin'
-          - 'firebase-functions'
-          - 'firebase-functions-test'
-          - '@simondotm/nx-firebase'
-      eslint:
-        applies-to: version-updates
-        patterns:
-          - 'eslint*'
-          - '@eslint/*'
-          - 'eslint-config-*'
-      typescript-eslint:
-        applies-to: version-updates
-        patterns:
-          - '@typescript-eslint/*'
-          - 'typescript-eslint'
-      typescript:
-        applies-to: version-updates
-        patterns:
-          - 'typescript'
-          - 'tslib'
-      swc:
-        applies-to: version-updates
-        patterns:
-          - '@swc*'
-      jest:
-        applies-to: version-updates
-        patterns:
-          - 'jest'
-          - 'jest-*'
-          - '@jest/*'
-          - 'ts-jest'
-      tailwindcss:
-        applies-to: version-updates
-        patterns:
-          - 'tailwindcss'
-          - '@tailwindcss/*'
-      types:
-        applies-to: version-updates
-        patterns:
-          - '@types/*'
+      production-minor-patch:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
+      development-minor-patch:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -84,3 +33,8 @@ updates:
     labels:
       - 'dependencies'
       - 'github-actions'
+    groups:
+      actions-minor-patch:
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
## Summary

Replace the 12 per-pattern groups (`angular`, `nx`, `firebase`, `firebase-admin`, `eslint`, `typescript-eslint`, `typescript`, `swc`, `jest`, `tailwindcss`, `types`) with broad minor+patch buckets per `dependency-type`. Adds the same grouping to `github-actions`. Preserves the `@move4mobile*` ignore.

## Why

Mirrors the fix from `onlineoffers-v2#191`. The previous setup produced one PR per named group per cycle; the recent batch produced two PRs (`#512`, `#513`) where merging `#513` immediately put `#512` into a conflict requiring rebase. With broad buckets, both would have shipped as one PR.

## Strategy

- **Minor + patch updates → bundled** by `dependency-type` (production / development / actions). One PR per bucket per cycle.
- **Major bumps → individual** (fall outside `update-types`), so they get manual review.

Angular packages still update together (they all share the same minor cycle), now bundled with other production deps in a single PR.

## Test plan

- [ ] Wait for next scheduled Dependabot run (daily 07:00 Amsterdam) to verify bundling
- [ ] Verify Angular majors still arrive as a single coordinated PR
- [ ] Verify `@move4mobile*` packages remain ignored