### PR TITLE
chore(deps): hold blocked majors (Angular, firebase-admin) in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,17 @@ updates:
       - 'dependencies'
     ignore:
       - dependency-name: '@move4mobile*'
+      # Angular majors are coupled to Nx — @nx/angular@23 peers cap the
+      # Angular toolchain < 22.0.0. Hold major bumps until Nx supports them
+      # (run via nx migrate, not standalone). Minor/patch still flow.
+      - dependency-name: '@angular*'
+        update-types:
+          - 'version-update:semver-major'
+      # firebase-admin v14 is blocked by firebase-functions@7 peer
+      # (^11||^12||^13). Hold the major until firebase-functions relaxes it.
+      - dependency-name: 'firebase-admin'
+        update-types:
+          - 'version-update:semver-major'
     groups:
       production-minor-patch:
         dependency-type: 'production'


### PR DESCRIPTION
## What

Add Dependabot `ignore` rules for two dependency majors that are currently **blocked upstream** and cannot be merged:

- **`@angular*` majors** — coupled to Nx. `@nx/angular@23.0.1` peer-caps the Angular toolchain at `>= 19.0.0 < 22.0.0`, so Angular 22 (and `@angular/cdk@22`, etc.) can't land until Nx ships support. Angular majors should ride `nx migrate`, not standalone Dependabot PRs.
- **`firebase-admin` major** — blocked by `firebase-functions@7.2.5`, which peers `^11||^12||^13` and ERESOLVE-fails on v14.

Only `version-update:semver-major` is ignored — minor/patch updates for these packages still flow normally.

## Why

Dependabot kept reopening unmergeable PRs (#566 `@angular/cdk` 22, #544 `firebase-admin` 14). This stops the churn until the upstream blocks lift.

## Test plan
- [x] YAML validated (well-formed, ignore syntax matches Dependabot v2 schema)
- [ ] Dependabot re-evaluates on next scheduled run and skips the blocked majors